### PR TITLE
124 created Tokens app

### DIFF
--- a/backend/Tokens/admin.py
+++ b/backend/Tokens/admin.py
@@ -1,3 +1,0 @@
-from django.contrib import admin
-
-# Register your models here.

--- a/backend/Tokens/admin.py
+++ b/backend/Tokens/admin.py
@@ -1,0 +1,3 @@
+from django.contrib import admin
+
+# Register your models here.

--- a/backend/Tokens/apps.py
+++ b/backend/Tokens/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class TokensConfig(AppConfig):
+    default_auto_field = 'django.db.models.BigAutoField'
+    name = 'Tokens'

--- a/backend/Tokens/managers.py
+++ b/backend/Tokens/managers.py
@@ -1,39 +1,39 @@
 from django.db import models
 from django.db import transaction
-from datetime import datetime
+from django.utils import timezone
+from datetime import timedelta
 
 class AuthenticatedGuestUserTokenManager(models.Manager):
 	def get_or_create_token(self, host_user, guest_user):
-		with transaction.atomic():
-			try:
-				guest_token = self.get_queryset().filter(
-                    host_user=host_user,
-                    guest_user=guest_user
-                ).latest('created_at')
+		try:
+			guest_token = self.get_queryset().filter(
+				host_user=host_user,
+				guest_user=guest_user
+			).latest('created_at')
 
-				if guest_token.is_expired():
-					# If the latest token has expired, deactivate it and create a new one
-					guest_token.is_active = False
-					guest_token.save()
-					guest_token = self.create(
-						host_user=host_user,
-						guest_user=guest_user
-					)
-				else:
-					# If the latest token has not expired and is still active, update creation time, else create a new token
-					if guest_token.is_active == True:
-						guest_token.created_at = datetime.now() 
-						guest_token.save()
-					else:
-						guest_token = self.create(
-						host_user=host_user,
-						guest_user=guest_user
-						)
-			except models.ObjectDoesNotExist:
-				# If no token exists, create a new one
+			if guest_token.is_expired():
+				# If the latest token has expired, deactivate it and create a new one
+				guest_token.is_active = False
+				guest_token.save()
 				guest_token = self.create(
 					host_user=host_user,
 					guest_user=guest_user
 				)
+			else:
+				# If the latest token has not expired and is still active, update creation time, else create a new token
+				if guest_token.is_active == True:
+					guest_token.expires_at = timezone.now() + timedelta(minutes=5) 
+					guest_token.save()
+				else:
+					guest_token = self.create(
+					host_user=host_user,
+					guest_user=guest_user
+					)
+		except models.ObjectDoesNotExist:
+			# If no token exists, create a new one
+			guest_token = self.create(
+				host_user=host_user,
+				guest_user=guest_user
+			)
 
 		return guest_token

--- a/backend/Tokens/managers.py
+++ b/backend/Tokens/managers.py
@@ -1,0 +1,39 @@
+from django.db import models
+from django.db import transaction
+from datetime import datetime
+
+class AuthenticatedGuestUserTokenManager(models.Manager):
+	def get_or_create_token(self, host_user, guest_user):
+		with transaction.atomic():
+			try:
+				guest_token = self.get_queryset().filter(
+                    host_user=host_user,
+                    guest_user=guest_user
+                ).latest('created_at')
+
+				if guest_token.is_expired():
+					# If the latest token has expired, deactivate it and create a new one
+					guest_token.is_active = False
+					guest_token.save()
+					guest_token = self.create(
+						host_user=host_user,
+						guest_user=guest_user
+					)
+				else:
+					# If the latest token has not expired and is still active, update creation time, else create a new token
+					if guest_token.is_active == True:
+						guest_token.created_at = datetime.now() 
+						guest_token.save()
+					else:
+						guest_token = self.create(
+						host_user=host_user,
+						guest_user=guest_user
+						)
+			except models.ObjectDoesNotExist:
+				# If no token exists, create a new one
+				guest_token = self.create(
+					host_user=host_user,
+					guest_user=guest_user
+				)
+
+		return guest_token

--- a/backend/Tokens/models.py
+++ b/backend/Tokens/models.py
@@ -1,0 +1,40 @@
+from django.db import models
+import uuid
+from datetime import timedelta
+from django.utils import timezone
+
+from User.models import User
+from .managers import AuthenticatedGuestUserTokenManager
+
+class AbstractToken(models.Model):
+    token = models.UUIDField(default=uuid.uuid4, editable=False, unique=True)
+    created_at = models.DateTimeField(auto_now_add=True)
+    expires_at = models.DateTimeField()
+    is_active = models.BooleanField(default=True)
+
+    class Meta:
+        abstract = True
+
+    def save(self, *args, **kwargs):
+        if not self.expires_at:
+            self.expires_at = timezone.now() + timedelta(minutes=5)
+        super().save(*args, **kwargs)
+
+    def is_expired(self):
+        return timezone.now() > self.expires_at
+
+    def __str__(self):
+        return str(self.token)
+
+
+class AuthenticatedGuestUserToken(AbstractToken):
+	host_user = models.ForeignKey(User, related_name='host_tokens', on_delete=models.CASCADE)
+	guest_user = models.ForeignKey(User, related_name='guest_tokens', on_delete=models.CASCADE)
+	
+
+	objects = AuthenticatedGuestUserTokenManager()
+
+	class Meta:
+		constraints = [
+			models.CheckConstraint(check=~models.Q(host_user=models.F('guest_user')), name='host_guest_not_same')
+		]

--- a/backend/Tokens/serializers.py
+++ b/backend/Tokens/serializers.py
@@ -1,0 +1,12 @@
+from rest_framework import serializers
+from .models import AbstractToken, AuthenticatedGuestUserToken
+
+class AbstractTokenSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = AbstractToken
+        fields = ['token']
+
+
+class AuthenticatedGuestUserTokenSerializer(AbstractTokenSerializer):
+    class Meta(AbstractTokenSerializer.Meta):
+        model = AuthenticatedGuestUserToken

--- a/backend/Tokens/tests.py
+++ b/backend/Tokens/tests.py
@@ -1,0 +1,3 @@
+from django.test import TestCase
+
+# Create your tests here.

--- a/backend/Tokens/views.py
+++ b/backend/Tokens/views.py
@@ -1,0 +1,56 @@
+from django.shortcuts import render
+from rest_framework.views import APIView
+from rest_framework.response import Response
+from rest_framework import status
+from django.contrib.auth import authenticate
+from django.utils.decorators import method_decorator
+
+from User.models import User
+from User.serializers import UserInputSerializer, \
+								UserOutputSerializer
+
+from .models import AuthenticatedGuestUserToken
+from .serializers import AuthenticatedGuestUserTokenSerializer
+from shared_utilities.decorators import must_be_authenticated, \
+											must_not_be_username, \
+											valid_serializer_in_body
+
+# Create your views here.
+class GuestUserAuthenticationView(APIView):
+	@method_decorator(must_be_authenticated)
+	@method_decorator(must_not_be_username)
+	@method_decorator(valid_serializer_in_body(UserInputSerializer))
+	def post(self, request):
+		host_user = request.user
+		username = request.data.get('username')
+		password = request.data.get('password')
+
+		user = authenticate(username=username, password=password)
+		if user is not None:
+			token = AuthenticatedGuestUserToken.objects.get_or_create_token(host_user=host_user, guest_user=user)
+			token_serializer = AuthenticatedGuestUserTokenSerializer(token)
+			user_serializer = UserOutputSerializer(user)
+			return Response({
+                'token': token_serializer.data,
+                'guest_user': user_serializer.data
+            }, status=status.HTTP_201_CREATED)
+		else:
+			return Response({'error': 'Invalid credentials'}, status=status.HTTP_400_BAD_REQUEST)
+		
+class DeactivateGuestUserTokenView(APIView):
+	@method_decorator(valid_serializer_in_body(AuthenticatedGuestUserTokenSerializer))
+	@method_decorator(must_be_authenticated)
+	def post(self, request):
+		try:
+			token = AuthenticatedGuestUserToken.objects.get(token=request.data.get('token'))
+			if token.is_active == False or token.is_expired():
+				token.is_active = False
+				token.save()
+				return Response({'message': 'Token has already expired'}, status=status.HTTP_200_OK)
+			else:
+				token.is_active = False
+				token.save()
+				return Response({'message': 'Token has expired'}, status=status.HTTP_200_OK)
+
+		except AuthenticatedGuestUserToken.DoesNotExist:
+			return Response({'error': 'Invalid token'}, status=status.HTTP_400_BAD_REQUEST)

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -55,6 +55,7 @@ INSTALLED_APPS = [
     # Backend apps here
     'User',
     'Friends',
+	'Tokens'
 ]
 
 MIDDLEWARE = [

--- a/backend/backend/urls.py
+++ b/backend/backend/urls.py
@@ -27,6 +27,9 @@ from User.views import UserDetailView, \
 from Friends.views import FriendsListView, \
 						FriendshipDetailView
 
+from Tokens.views import GuestUserAuthenticationView, \
+							DeactivateGuestUserTokenView
+
 urlpatterns = [
 	path('admin/', admin.site.urls),
 
@@ -41,4 +44,8 @@ urlpatterns = [
 	# Friends views
 	path('friends/', FriendsListView.as_view()),
 	path('friends/<int:friend_id>', FriendshipDetailView.as_view()),
+
+	# Tokens views
+	path('authenticate-guest-user/', GuestUserAuthenticationView.as_view()),
+	path('remove-guest-user/', DeactivateGuestUserTokenView.as_view()),
 ]

--- a/backend/shared_utilities/decorators.py
+++ b/backend/shared_utilities/decorators.py
@@ -82,5 +82,23 @@ def valid_serializer_in_body(serializer_class, **kwargs):
 		return wrapper
 	return decorator
 
+# Used with GuestUserAuthenticationView to prevent the host user from authenticating themself
+def must_not_be_username(view_func):
+	@wraps(view_func)
+	def wrapper(*args, **kwargs):
+		request = args[0] if args else None
 
+		try:
+			username = request.data.get('username')
+		except KeyError:
+			return HttpResponseForbidden("Missing 'username' in request data.")
+
+		if request.user.is_superuser:
+			return view_func(*args, **kwargs)
+
+		if request.user.username == username:
+			return HttpResponseForbidden("request data username has to be different from the logged in user's username.")
+
+		return view_func(*args, **kwargs)
+	return wrapper
 


### PR DESCRIPTION
This was something I was originally going to have in the match-api pr, but I realised that it's most likely better to have it's own app and pr for it.
As the name says, I've created a new Tokens app. The tokens will be utilised with matches and tournaments.

In the models.py I have an AbstractToken which will work as the parent for all the tokens we might need with our project. The most important field in this abstract model is the 'token', which has a unique uuid string value. I have also created an AuthorizedGuestUserToken model that of course inherits from the AbstractToken. It has a couple extra foreignkeyfields such as host_user and guest_user, which will be set when the guest user authenticates themself. I've created a serializer for this model that only has the token field in it.

The idea is that when the guest user successfully authenticates themself in host user's lobby, the view will return two serializers like this:
```
{
    "token": {
        "token": "3bbfa841-73a7-45ac-b3dc-55bd6f214c28"
    },
    "guest_user": {
        "id": 2,
        "username": "guest",
        "is_online": false
    }
}
```
the guest_user data will come in handy when showing their profile, but if you don't want the current response body, please inform me and I will do something else then.
the token will be passed later to a view when launching the match (working on that currently on the 115 branch).

I've also created a view for removing the guest user. You pass the token to this view, and it will simply set the token's is_active field to false, which prevents its use later on.


I've tested the views with postman and everything works. You can check out the rest of the pr yourself, but it's good that especially @dorianjagusch knows how I imagine authenticating the guest user works exactly.