### PR TITLE
137 - refactored LaunchMatchView

### DIFF
--- a/backend/Match/managers.py
+++ b/backend/Match/managers.py
@@ -1,7 +1,7 @@
 from django.db import models, transaction, IntegrityError
 from django.db.models import Q
 
-from .PlayerMatchStatus import PlayerMatchStatus
+from .playerMatchStatus import PlayerMatchStatus
 from Player.models import Player
 from User.models import User
 

--- a/backend/Match/views.py
+++ b/backend/Match/views.py
@@ -5,37 +5,35 @@ from rest_framework.request import Request
 from rest_framework import status
 from django.shortcuts import redirect
 
-from User.models import User
-from .models import Match
 from Tokens.models import MatchToken
-from Tokens.serializers import MatchTokenSerializer
 from shared_utilities.GameSetupManager import GameSetupManager
 from django.utils.decorators import method_decorator
-from shared_utilities.decorators import must_be_authenticated, \
-											valid_serializer_in_body
+from shared_utilities.decorators import must_be_authenticated
 
+class LaunchMatchView(APIView):
+    @method_decorator(must_be_authenticated)
+    def get(self, request):
+        token_str = request.query_params.get('token')
+        if not token_str:
+            return Response({'error': 'Token parameter is required'}, status=status.HTTP_400_BAD_REQUEST)
 
-class LaunchSingleMatchView(APIView):
-	@method_decorator(must_be_authenticated)
-	@method_decorator(valid_serializer_in_body(MatchTokenSerializer))
-	def post(self, request):
-		try:
-			token = MatchToken.objects.get(token=request.data.get('token'))
-		except MatchToken.DoesNotExist:
-			return Response({'error': 'Invalid token'}, status=status.HTTP_400_BAD_REQUEST)
+        try:
+            token = MatchToken.objects.get(token=token_str)
+        except MatchToken.DoesNotExist:
+            return Response({'error': 'Invalid token'}, status=status.HTTP_400_BAD_REQUEST)
 
-		if token.is_active == False or token.is_expired():
-			return Response({'error': 'Expired token'}, status=status.HTTP_403_FORBIDDEN)
-		if token.user_left_side.id != request.user.id:
-			return Response({'error': 'You are not the host user in the token'}, status=status.HTTP_403_FORBIDDEN)
-		
-		match, host_player, guest_player = GameSetupManager.create_match_and_its_players(token)
+        if not token.is_active or token.is_expired():
+            return Response({'error': 'Expired token'}, status=status.HTTP_403_FORBIDDEN)
+        if token.user_left_side.id != request.user.id:
+            return Response({'error': 'You are not the host user in the token'}, status=status.HTTP_403_FORBIDDEN)
 
-		if not all([match, host_player, guest_player]):
-			return Response({'error': 'Something went wrong when creating the match and players'}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
-		
-		pong_match_url = f'http://localhost:80/pong/{match.id}?token={token.token}'
-		return redirect(pong_match_url) # this is prob not correct as this is a single-page app...
+        match, player_left, player_right = GameSetupManager.create_match_and_its_players(token)
+
+        if not all([match, player_left, player_right]):
+            return Response({'error': 'Something went wrong when creating the match and players'}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+        pong_match_url = f'http://localhost:80/pong/{match.id}?token={token.token}'
+        return Response({'match_url': pong_match_url}, status=status.HTTP_200_OK)
 
 
 class LaunchTestMatchView(APIView):

--- a/backend/Match/views.py
+++ b/backend/Match/views.py
@@ -10,7 +10,7 @@ from shared_utilities.GameSetupManager import GameSetupManager
 from django.utils.decorators import method_decorator
 from shared_utilities.decorators import must_be_authenticated
 
-class LaunchMatchView(APIView):
+class MatchView(APIView):
     @method_decorator(must_be_authenticated)
     def get(self, request):
         token_str = request.query_params.get('token')

--- a/backend/backend/urls.py
+++ b/backend/backend/urls.py
@@ -31,7 +31,7 @@ from Friends.views import FriendsListView, \
 
 from Tokens.views import SingleMatchGuestTokenView
 
-from Match.views import LaunchSingleMatchView, \
+from Match.views import LaunchMatchView, \
 							LaunchTestMatchView
 
 urlpatterns = [
@@ -50,11 +50,11 @@ urlpatterns = [
 	path('friends/<int:friend_id>', FriendshipDetailView.as_view()),
 
 	# Tokens views
-	path('tokens/guest/match/', SingleMatchGuestTokenView.as_view()),
+	path('tokens/match/', SingleMatchGuestTokenView.as_view()),
 
 	# Match Views
-	path('start-single-match/', LaunchSingleMatchView.as_view()),
-	path('start-test-match/', LaunchTestMatchView.as_view()),
+	path('match/', LaunchMatchView.as_view()),
+	path('match/test/', LaunchTestMatchView.as_view()), # TEMPORARY
 ]
 
 websocket_urlpatterns = [

--- a/backend/backend/urls.py
+++ b/backend/backend/urls.py
@@ -31,7 +31,7 @@ from Friends.views import FriendsListView, \
 
 from Tokens.views import SingleMatchGuestTokenView
 
-from Match.views import LaunchMatchView, \
+from Match.views import MatchView, \
 							LaunchTestMatchView
 
 urlpatterns = [
@@ -53,7 +53,7 @@ urlpatterns = [
 	path('tokens/match/', SingleMatchGuestTokenView.as_view()),
 
 	# Match Views
-	path('match/', LaunchMatchView.as_view()),
+	path('match/', MatchView.as_view()),
 	path('match/test/', LaunchTestMatchView.as_view()), # TEMPORARY
 ]
 

--- a/postman_collection.json
+++ b/postman_collection.json
@@ -1927,62 +1927,6 @@
 					"response": []
 				},
 				{
-					"name": "view 123 friends",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"var xsrfCookie = postman.getResponseCookie(\"csrftoken\");",
-									"pm.collectionVariables.set(\"user123_csrftoken\", xsrfCookie.value);",
-									"var sessionIdCookie = postman.getResponseCookie(\"sessionid\");",
-									"pm.collectionVariables.set(\"user123_sessionid\", sessionIdCookie.value);"
-								],
-								"type": "text/javascript",
-								"packages": {}
-							}
-						}
-					],
-					"protocolProfileBehavior": {
-						"disableBodyPruning": true
-					},
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "X-CSRFToken",
-								"value": "{{user123_csrftoken}}",
-								"type": "text"
-							},
-							{
-								"key": "sessionid",
-								"value": "{{user123_sessionid}}",
-								"type": "text"
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"username\": \"123\",\n    \"password\": \"123\"\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseurl}}/friends/",
-							"host": [
-								"{{baseurl}}"
-							],
-							"path": [
-								"friends",
-								""
-							]
-						}
-					},
-					"response": []
-				},
-				{
 					"name": "authenticate guest2",
 					"event": [
 						{
@@ -2024,12 +1968,13 @@
 							}
 						},
 						"url": {
-							"raw": "{{baseurl}}/authenticate-guest-user-for-single-match/",
+							"raw": "{{baseurl}}/tokens/match/",
 							"host": [
 								"{{baseurl}}"
 							],
 							"path": [
-								"authenticate-guest-user-for-single-match",
+								"tokens",
+								"match",
 								""
 							]
 						}
@@ -2076,8 +2021,11 @@
 				},
 				{
 					"name": "launch single match against guest2",
+					"protocolProfileBehavior": {
+						"disableBodyPruning": true
+					},
 					"request": {
-						"method": "POST",
+						"method": "GET",
 						"header": [
 							{
 								"key": "x-csrftoken",
@@ -2092,7 +2040,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"token\": \"{{guest2_token}}\"\n}",
+							"raw": "",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -2100,13 +2048,19 @@
 							}
 						},
 						"url": {
-							"raw": "{{baseurl}}/start-single-match/",
+							"raw": "{{baseurl}}/match/?token={{guest2_token}}",
 							"host": [
 								"{{baseurl}}"
 							],
 							"path": [
-								"start-single-match",
+								"match",
 								""
+							],
+							"query": [
+								{
+									"key": "token",
+									"value": "{{guest2_token}}"
+								}
 							]
 						}
 					},
@@ -2129,12 +2083,13 @@
 							}
 						],
 						"url": {
-							"raw": "{{baseurl}}/start-test-match/",
+							"raw": "{{baseurl}}/match/test/",
 							"host": [
 								"{{baseurl}}"
 							],
 							"path": [
-								"start-test-match",
+								"match",
+								"test",
 								""
 							]
 						}


### PR DESCRIPTION
Refactored some stuff that were brought up in #133  review.

- Refactored LaunchSingleMatchView into MatchView
  - now it's a GET request that is passed the token value you get from authenticating the guest user like '{{baseurl}}/match/?token={{token_value}}'
- changed the file PlayerMatchStatus.py into playerMatchStatus.py
- updated the tests for match, token folder in postman collection (old version, not @merituulie new version)