### PR TITLE
141 fix match url

### DIFF
--- a/backend/Match/views.py
+++ b/backend/Match/views.py
@@ -32,7 +32,7 @@ class MatchView(APIView):
         if not all([match, player_left, player_right]):
             return Response({'error': 'Something went wrong when creating the match and players'}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
-        pong_match_url = f'http://localhost:80/pong/{match.id}?token={token.token}'
+        pong_match_url = f'ws://localhost:8080/pong/{match.id}?token={token.token}'
         return Response({'match_url': pong_match_url}, status=status.HTTP_200_OK)
 
 
@@ -44,5 +44,5 @@ class LaunchTestMatchView(APIView):
 		if not all([match, player_left_side, player_right_side]):
 			return Response({'error': 'Something went wrong when creating the match and players'}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 		
-		pong_match_url = f'http://localhost:80/pong/{match.id}?token={token.token}'
-		return redirect(pong_match_url)
+		pong_match_url = f'ws://localhost:8080/pong/{match.id}?token={token.token}'
+		return Response({'match_url': pong_match_url}, status=status.HTTP_200_OK)

--- a/backend/Match/views.py
+++ b/backend/Match/views.py
@@ -33,7 +33,7 @@ class MatchView(APIView):
             return Response({'error': 'Something went wrong when creating the match and players'}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
         pong_match_url = f'ws://localhost:8080/pong/{match.id}?token={token.token}'
-        return Response({'match_url': pong_match_url}, status=status.HTTP_200_OK)
+        return Response(pong_match_url, status=status.HTTP_200_OK)
 
 
 class LaunchTestMatchView(APIView):
@@ -45,4 +45,4 @@ class LaunchTestMatchView(APIView):
 			return Response({'error': 'Something went wrong when creating the match and players'}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 		
 		pong_match_url = f'ws://localhost:8080/pong/{match.id}?token={token.token}'
-		return Response({'match_url': pong_match_url}, status=status.HTTP_200_OK)
+		return Response(pong_match_url, status=status.HTTP_200_OK)

--- a/backend/backend/urls.py
+++ b/backend/backend/urls.py
@@ -60,7 +60,3 @@ urlpatterns = [
 websocket_urlpatterns = [
     path('pong/<int:match_id>', PongConsumer.as_asgi()),
 ]
-
-websocket_urlpatterns = [
-	path('pong/<int:match_id>', PongConsumer.as_asgi()),
-]


### PR DESCRIPTION
The url that you get when you launch a match is now fixed (replaced http with ws; also replaced port 80 with 8080)
Removed extra websocket_urlpatterns from the urls.py
Added some stuff that was missing in the consumers.py.

Something we will have to remember for later: because I've added the whole test match feature where the user can play the pong game against themself for easy development of the pong game, I had to change the retrieval of the players from the database:

earlier the line was
self.player_left = Player.objects.get(match=self.match, user_id=match_token.user_left_side)
which causes an error when playing against oneself because this will return two player models, so now it is
self.player_left = Player.objects.filter(match=self.match, user_id=match_token.user_left_side).first()

We'll have to remember to change this back when we are finished with the development of the project.