### PR TITLE
Update requirements, change image name for back and front

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ CYAN = \033[0;96m
 all: up
 
 up:
-	${DOCKER_COMPOSE} up --build --detach
+	sudo ${DOCKER_COMPOSE} up --build --detach
 	@echo "${GREEN}${NAME} is up!${C_RESET}"
 
 prod:
@@ -44,11 +44,11 @@ stop:
 	@echo "${GREEN}${NAME} has stopped!${C_RESET}"
 
 clean: stop
-	${DOCKER_COMPOSE} down -v
+	sudo ${DOCKER_COMPOSE} down -v
 	@echo "${GREEN}${NAME} has been cleaned!${C_RESET}"
 
 fclean: clean
-	${DOCKER_COMPOSE} down --rmi all --volumes --remove-orphans
+	sudo ${DOCKER_COMPOSE} down --rmi all --volumes --remove-orphans
 
 re: fclean all
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,9 +1,9 @@
 asgiref==3.8.1
-Django==5.0.4
-djangorestframework==3.15.1
-sqlparse==0.4.4
-typing_extensions==4.11.0
+Django==5.0.6
+djangorestframework==3.15.2
+sqlparse==0.5.0
+typing_extensions==4.12.2
 psycopg2==2.9.9
-django-cors-headers==3.10.
+django-cors-headers==3.10.1
 channels==4.1.0
 daphne==4.1.2

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -29,7 +29,7 @@ services:
      - ft_transcendence_network
 
   backend:
-    image: backend:42
+    image: backend:adsjm
     container_name: backend_c
     build:
       context: ./backend
@@ -51,7 +51,7 @@ services:
   frontend:
     build:
       context: ./frontend
-    image: frontend:42
+    image: frontend:adsjm
     container_name: frontend_c
     volumes:
       - ./frontend/nginx.conf:/etc/nginx/nginx.conf:ro


### PR DESCRIPTION
- Added sudos to Makefile be sure make does not fail there.
- Updated packages in requirements.txt
- Changed the image tag name, if the compose is given a docker hub existing image:tag combination, it can pull the image from the docker hub, 42 is just too used as all of Hive uses this number.