### PR TITLE
Added proper websocket closing when user navigates away

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -157,3 +157,8 @@ GitHub.sublime-settings
 
 #Ignore personal notes
 notes.txt
+
+#frontend testing
+**/node_modules/
+frontend/**/tests
+frontend/**/package*.json

--- a/frontend/static/js/pong/ChatSocket.js
+++ b/frontend/static/js/pong/ChatSocket.js
@@ -2,7 +2,15 @@ import PongGame from './pongGame.js';
 
 class ChatSocket {
 	constructor(url) {
-		this.chatSocket = new WebSocket(url);
+
+		this.chatSocket = null;
+
+		try {
+			this.chatSocket = new WebSocket(url);
+		} catch (error) {
+			throw new Error('Could not connect to chat socket');
+		}
+
 		this.acceptMessage = this.acceptMessage.bind(this);
 		this.handleClose = this.handleClose.bind(this);
 		this.handleError = this.handleError.bind(this);
@@ -21,13 +29,16 @@ class ChatSocket {
 	}
 
 	handleClose(e) {
-		console.error('Chat socket closed unexpectedly');
-		this.removeEventListeners();
+		if (this.chatSocket && this.chatSocket.readyState == WebSocket.OPEN) {
+			this.chatSocket.close();
+			this.removeEventListeners();
+			this.chatSocket = null;
+		}
 	}
 
 	handleError(e) {
 		console.error('Chat socket error:', e);
-		if (chatSocket.readyState == WebSocket.OPEN) {
+		if (this.chatSocket && chatSocket.readyState == WebSocket.OPEN) {
 			chatSocket.close();
 		}
 		this.removeEventListeners();
@@ -38,10 +49,12 @@ class ChatSocket {
 	}
 
 	removeEventListeners() {
-		this.chatSocket.removeEventListener('close', this.handleClose);
-		this.chatSocket.removeEventListener('error', this.handleError);
-		this.chatSocket.removeEventListener('message', this.acceptMessage);
-		window.removeEventListener('keyup', this.sendKey);
+		if (this.chatSocket){
+			this.chatSocket.removeEventListener('close', this.handleClose);
+			this.chatSocket.removeEventListener('error', this.handleError);
+			this.chatSocket.removeEventListener('message', this.acceptMessage);
+			window.removeEventListener('keyup', this.sendKey);
+		}
 	}
 
 	connect() {

--- a/frontend/static/js/views/pongView.js
+++ b/frontend/static/js/views/pongView.js
@@ -11,6 +11,29 @@ export default class extends AView {
 		this.setTitle('Pong');
 		this.chatSocket = null;
 		this.pongService = new PongService();
+		this.attachEventListeners = this.attachEventListeners.bind(this);
+	}
+
+	attachEventListeners() {
+		document.querySelectorAll('.nav-link').forEach((link) => {
+			link.addEventListener('click', this.chatSocket.handleClose);
+		});
+
+		window.addEventListener('beforeunload', this.chatSocket.handleClose);
+
+		const observer = new MutationObserver((mutationsList, observer) => {
+			for (let mutation of mutationsList) {
+				if (mutation.removedNodes) {
+					mutation.removedNodes.forEach((node) => {
+						if (node.id = "pong") {
+							this.chatSocket.handleClose();
+							observer.disconnect();
+						}
+					});
+				}
+			}
+		});
+		observer.observe(document.body, {childList: true, subtree: true});
 	}
 
 	async getHTML() {
@@ -20,10 +43,12 @@ export default class extends AView {
 			this.chatSocket = new ChatSocket(matchUrl);
 			this.chatSocket.connect();
 		} catch (error) {
-			console.log(error);
+			this.notify(error);
+			this.navigateTo('/play');
 		}
 
 		const pong = Pong.PongContainer();
 		this.updateMain(pong);
+		this.attachEventListeners();
 	}
 }

--- a/frontend/static/js/views/pongView.js
+++ b/frontend/static/js/views/pongView.js
@@ -2,8 +2,6 @@ import ChatSocket from '../pong/ChatSocket.js';
 import PongService from '../services/pongService.js';
 import Pong from '../pong/pong.js';
 import AView from './AView.js';
-import PongGame from '../pong/pongGame.js';
-
 
 export default class extends AView {
 	constructor(params) {

--- a/text.html
+++ b/text.html
@@ -1,0 +1,8 @@
+<main>
+	<section id="pong">
+		<article>ererv</article>
+		<article>werwrferf</article>
+		<article>weeferf</article>
+		<article>weferf</article>
+	</section>
+</main>

--- a/text.html
+++ b/text.html
@@ -1,8 +1,0 @@
-<main>
-	<section id="pong">
-		<article>ererv</article>
-		<article>werwrferf</article>
-		<article>weeferf</article>
-		<article>weferf</article>
-	</section>
-</main>


### PR DESCRIPTION
Another day another win!

Now navigating away from the pong page, be it by browser navigation, url or the navbar, the socket is being closed and the evenhandlers removed to prevent them from doing the shenanigans they did. 

## Changes
- Added an event listeners on the navbar, indirectly on the browser buttons and lastly   a mutation observer that continuously looks for changes in the DOM. When detected whether it is the element with id "pong" (given that there is only one pong page and ids are unique anyway), it finds, disables and overrides the websocket :D

## Caveats
The event appending on the navbar could be improved by taking advantage of event delegation