### PR TITLE
201 add user search by username fragments

### DIFF
--- a/backend/Friends/managers.py
+++ b/backend/Friends/managers.py
@@ -3,6 +3,7 @@ from .friendShipStatus import FriendShipStatus
 from User.models import User
 from django.db import transaction
 
+
 class FriendsManager(models.Manager):
 	def get_user_friends(self, user_id, friendship_status):
 		user_friends = self.filter(user_id=user_id).values_list('friend_id', flat=True)
@@ -23,7 +24,7 @@ class FriendsManager(models.Manager):
 		friends = User.objects.filter(id__in=friends_to_get)
 		return friends
 
-	def get_friendship_status(self, user_id, friend_id):
+	def get_friendship_status(self, user_id: int, friend_id: int):
 		user_friend = self.filter(user_id=user_id, friend_id=friend_id)
 		friend_user = self.filter(user_id=friend_id, friend_id=user_id)
 		if user_friend.exists() and friend_user.exists():

--- a/backend/User/serializers.py
+++ b/backend/User/serializers.py
@@ -1,5 +1,7 @@
 from rest_framework import serializers
 from .models import User
+from Friends.managers import FriendsManager
+from Friends.models import Friend
 
 class UserInputSerializer(serializers.ModelSerializer):
 	password = serializers.CharField(write_only=True)
@@ -13,7 +15,7 @@ class UserOutputSerializer(serializers.ModelSerializer):
 		model = User
 		fields = ['id', 'username', 'is_online']
 
-    
+
 class UserFriendOutputSerializer(serializers.ModelSerializer):
 	friendship = serializers.SerializerMethodField()
 
@@ -21,9 +23,10 @@ class UserFriendOutputSerializer(serializers.ModelSerializer):
 		model = User
 		fields = ['id', 'username', 'is_online', 'friendship']
 
-	def __init__(self, *args, **kwargs):
-		self.friendship = kwargs.pop('friendship', None)
-		super().__init__(*args, **kwargs)
-
 	def get_friendship(self, obj):
-			return self.friendship
+		user_id = self.context['request'].user.id
+		friend_id = obj.id
+		if (not user_id or not friend_id):
+			return None
+		status = FriendsManager.get_friendship_status(Friend.objects, user_id, friend_id)
+		return status

--- a/backend/User/views.py
+++ b/backend/User/views.py
@@ -23,6 +23,13 @@ from shared_utilities.decorators import must_be_authenticated, \
 
 class UserListView(APIView):
 	def get(self, request):
+		if request.user.is_authenticated and request.GET.get("username_contains"):
+			username_contains = request.GET.get("username_contains")
+			users = User.objects.filter(username__contains=username_contains).exclude(id=request.user.id)
+			## add error handling if either user doesn't exits or user is not authenticated
+			serializer = UserFriendOutputSerializer(users, many=True, context={'request': request})
+			return Response(serializer.data, status=status.HTTP_200_OK)
+
 		users = User.objects.all()
 		serializer = UserOutputSerializer(users, many=True)
 		return Response(serializer.data, status=status.HTTP_200_OK)
@@ -56,7 +63,7 @@ class UserDetailView(APIView):
 			serializer = UserOutputSerializer(user)
 			return Response(serializer.data)
 		friendship = Friend.objects.get_friendship_status(login_user_id, user.id)
-		serializer = UserFriendOutputSerializer(user, friendship=friendship)
+		serializer = UserFriendOutputSerializer(user, context={'request': request})
 		return Response(serializer.data)
 
 	@method_decorator(must_be_authenticated)

--- a/frontend/static/js/components/formComponents/searchResultCard.js
+++ b/frontend/static/js/components/formComponents/searchResultCard.js
@@ -1,6 +1,6 @@
 import buttonBar from '../profileComponents/buttonBar.js';
 
-const searchResultCard = ({username, img, id, relationship}, buttonSelector) => {
+const searchResultCard = ({username, img, id, friendship}, buttonSelector) => {
 	const searchResult = document.createElement('div');
 	searchResult.classList.add('friend-result', 'bg-primary');
 	searchResult.setAttribute('data-id', id);
@@ -13,7 +13,7 @@ const searchResultCard = ({username, img, id, relationship}, buttonSelector) => 
 	friendName.classList.add('friend-name');
 	friendName.textContent = username;
 
-	const friendActions = buttonBar(buttonSelector(relationship));
+	const friendActions = buttonBar(buttonSelector(friendship));
 
 	searchResult.appendChild(avatarImg);
 	searchResult.appendChild(friendName);

--- a/frontend/static/js/services/userService.js
+++ b/frontend/static/js/services/userService.js
@@ -10,8 +10,13 @@ class UserService extends ARequestService {
 		return super.getRequest(`${backendURL.userURL}${id}`);
 	}
 
-	async getAllRequest() {
-		return super.getAllRequest(`${backendURL.userURL}`);
+	async getAllRequest(params) {
+		const url = new URL(backendURL.userURL);
+		Object.entries(params).forEach(([key, value]) => {
+			url.searchParams.append(key, value);
+		});
+		console.log(url);
+		return super.getAllRequest(`${url}`);
 	}
 
 	async postRequest({username, password}) {

--- a/frontend/static/js/services/userService.js
+++ b/frontend/static/js/services/userService.js
@@ -15,7 +15,6 @@ class UserService extends ARequestService {
 		Object.entries(params).forEach(([key, value]) => {
 			url.searchParams.append(key, value);
 		});
-		console.log(url);
 		return super.getAllRequest(`${url}`);
 	}
 

--- a/frontend/static/js/views/matchView.js
+++ b/frontend/static/js/views/matchView.js
@@ -40,7 +40,6 @@ export default class extends Aview {
 	}
 
 	attachPlayerInfo(guestUserData) {
-		console.log(guestUserData);
 		const playerRight = PlayerInfo(guestUserData);
 
 		const container = document.createElement('div');


### PR DESCRIPTION
Search of users by (partial) username works now.

It is probably not the cleanest solution. There is a bit too much logic in the Output serializer for my taste. If it's indeed to much for people and if the interdependence of the apps is too much for people, I am happy to change this with the help of our django experts. 

The current character limit until the search is started is 3 chars and only on the frontend!

## Changes:
- Added authentication barrier conditional branch to GET user/ endpoint 
- remodelled UserFriendOutputSerializer to work with querysets as well as singular objects
- Integrated user service with frontend to make use of the optional queryparameter

## Caveat:
- User image is currently not being retrieved until #193 is through


closes #201 