### PR TITLE
add scrolling to center canvas when going to pong page

### DIFF
--- a/backend/backend/urls.py
+++ b/backend/backend/urls.py
@@ -77,7 +77,6 @@ urlpatterns = [
 	path('tournaments/<int:tournament_id>', TournamentDetailView.as_view()),
 	path('tournaments/<int:tournament_id>/players/', TournamentPlayerListView.as_view()),
 	path('tournaments/<int:tournament_id>/players/<int:tournamentplayer_id>', TournamentPlayerDetailView.as_view()),
-]
 
 	# Stats Views
 	path('stats/', StatsView.as_view()),

--- a/frontend/static/js/views/pongView.js
+++ b/frontend/static/js/views/pongView.js
@@ -16,6 +16,30 @@ export default class extends AView {
 		this.attachEventListeners = this.attachEventListeners.bind(this);
 	}
 
+	scrollToCanvas(mutation) {
+		if (!mutation.addedNodes) {
+			return;
+		}
+		mutation.addedNodes.forEach((node) => {
+			if (node.tagName === 'CANVAS') {
+				document.querySelector('canvas').scrollIntoView({behavior: 'smooth', block: 'center'});
+			}
+		});
+	}
+
+	checkForPongClosing(mutation) {
+		if (!mutation.removedNodes) {
+			return;
+		}
+		mutation.removedNodes.forEach((node) => {
+			if (node.id != 'pong') {
+				return;
+			}
+			this.chatSocket.handleClose();
+			observer.disconnect();
+		});
+	}
+
 	attachEventListeners() {
 		document.querySelectorAll('.nav-link').forEach((link) => {
 			link.addEventListener('click', this.chatSocket.handleClose);
@@ -23,22 +47,13 @@ export default class extends AView {
 
 		window.addEventListener('beforeunload', this.chatSocket.handleClose);
 
-		// TODO unnest the conditionals in the loop
 		const observer = new MutationObserver((mutationsList, observer) => {
 			for (let mutation of mutationsList) {
-				if (!mutation.removedNodes) {
-					return;
-				}
-				mutation.removedNodes.forEach((node) => {
-					if ((node.id != 'pong')) {
-						return;
-					}
-						this.chatSocket.handleClose();
-						observer.disconnect();
-					}
-				)};
+				this.checkForPongClosing(mutation);
+				this.scrollToCanvas(mutation);
+			}
 		});
-		observer.observe(document.body.querySelector('main'), {childList: true, subtree: false});
+		observer.observe(document.body.querySelector('main'), {childList: true, subtree: true});
 	}
 
 	async getHTML() {
@@ -52,8 +67,8 @@ export default class extends AView {
 			this.navigateTo('/play');
 		}
 
+		this.attachEventListeners();
 		const pong = Pong.PongContainer();
 		this.updateMain(pong);
-		this.attachEventListeners();
 	}
 }


### PR DESCRIPTION
When the pong game canvas is created on the pong page, browser scrolls to center the canvas

## Changes:
- added scroll behaviour to pong page

## Caveats:
LMK if you want the instructions for the players to be closer to the bottom of the canvas, as the might not be visible depending on screen dimensions. I do know that #220 changes the playing field dimensions, so it might be void.