### PR TITLE
266-change-tournament-player-name-to-deleted-user

### DIFF
--- a/backend/Tournament/mixins.py
+++ b/backend/Tournament/mixins.py
@@ -1,0 +1,12 @@
+from User.models import User
+
+class ChangeDeletedUserTournamentNamesMixin:
+	"""
+    Mixin that changes a user's tournamentplayers' display names to deleted_user.
+	Use only when deleting a user.
+    """
+	def change_tournament_player_names_to_deleted(self, user: User) -> None:
+		tournament_players = user.tournament_players.all()
+		for player in tournament_players:
+			player.display_name = "deleted_user"
+			player.save()

--- a/backend/User/mixins.py
+++ b/backend/User/mixins.py
@@ -130,13 +130,13 @@ class DeleteUserMixin(ChangeDeletedUserTournamentNamesMixin):
         result.is_active = False
         result.is_staff = False
         result.is_superuser = False
-        result.insertTS = None
+        result.insert_ts = None
         result.last_login = None
         result.is_online = False
         result.save()
 
         self.change_tournament_player_names_to_deleted(result)
-        
+
         return Response(status=status.HTTP_204_NO_CONTENT)
 
 

--- a/backend/User/models.py
+++ b/backend/User/models.py
@@ -8,7 +8,7 @@ class User(AbstractBaseUser):
 	password = models.CharField('password', max_length=128, null=False, blank=False)
 	is_active = models.BooleanField('active', default=True)
 	is_superuser = models.BooleanField('is_superuser', default=False)
-	insertTS = models.DateTimeField('insertTS', auto_now_add=True, blank=True, null=True)
+	insert_ts = models.DateTimeField('insert_ts', auto_now_add=True, blank=True, null=True)
 	last_login = models.DateTimeField('last_login', blank=True, null=True)
 	is_online = models.BooleanField('is_online', default=False)
 


### PR DESCRIPTION
created Tournament mixin for changing a user's tournamentplayer display_names to 'deleted_user'.
used that mixin in User's DeleteUserMixin.

tested, works.

Not related to this pr or issue, but I'm not really happy with my naming conventions in some of the User app's mixins and views; For example, because something like GetUserMixin's get_user function can return either a user or a response, I don't want the code to have
`user = self.get_user(user_id)`
because the result could not be the user, and in that case it would be a bit strange to have something like
```
if not is instance(user, User):
        return user
```

so because of this I usually use
`result = self.get_user(user_id)`
but then for the rest of the mixin or view I have stuff like this
```
result.username = f"deleted_user_{user_id + 42}"
        result.set_password(get_random_string(length=30))
        result.is_active = False
        result.is_staff = False
        result.is_superuser = False
        result.insertTS = None
        result.last_login = None
        result.is_online = False
        result.save()
```
which is also strange.

Should I just write the code like this
```
result = self.get_user(user_id)
if not isinstance(result, User):
        response = result
        return response
user = result
#continue with function
```
even if it adds a couple of unnecessary lines? Just some general thoughts I'd appreciate some comments on...


