### PR TITLE
Add styles, fix password read

### DIFF
--- a/backend/User/mixins.py
+++ b/backend/User/mixins.py
@@ -84,7 +84,7 @@ class UpdateUserMixin:
 			outputSerializer = UserOutputSerializer(result)
 			return Response(outputSerializer.data, status=status.HTTP_200_OK)
 		except Exception as e:
-			return Response({"message": f"{str(e)}"}, status=status.HTTP_400_BAD_REQUEST)
+			return Response({"message": f"Updating the user failed"}, status=status.HTTP_400_BAD_REQUEST)
 
 
 class AuthenticateUserMixin:

--- a/frontend/static/css/styles.css
+++ b/frontend/static/css/styles.css
@@ -103,6 +103,7 @@ label,
 select,
 textarea {
 	line-height: 1.1;
+	margin-bottom: 0.3em;
 }
 
 button {
@@ -1311,6 +1312,11 @@ p:has(+ .menu-item) {
 dialog h3 {
 	text-align: center;
 	margin-bottom: 2em;
+}
+
+dialog h5 {
+	text-align: center;
+	margin-bottom: 1em;
 }
 
 dialog .notification {

--- a/frontend/static/js/components/formComponents/updateUserForm.js
+++ b/frontend/static/js/components/formComponents/updateUserForm.js
@@ -10,19 +10,23 @@ export default class UpdateUserForm extends AForm {
         const header = document.createElement('h3');
         header.textContent = 'Update Information';
 
-        const userNameField = InputField('text', 'Input new username', 'username');
-        const passwordField = InputField('password', 'Input new password', 'current-password');
-        const repeatPasswordField = InputField('password', 'Repeat new password', 'password');
+        const infoHeader = document.createElement('h5');
+        infoHeader.textContent = 'Changing the password will log you out.';
+
+        const userNameField = InputField('text', 'New username', 'username');
+        const passwordField = InputField('password', 'New password', 'current-password');
+        const repeatPasswordField = InputField('password', 'Repeat password', 'password');
         const updateUserButton = document.createElement('button');
         updateUserButton.classList.add('primary-btn');
         updateUserButton.setAttribute('type', 'submit');
+        updateUserButton.setAttribute('formmethod', 'dialog');
         updateUserButton.textContent = 'Save information';
 
         const buttonBar = document.createElement('div');
         buttonBar.classList.add('button-bar');
         buttonBar.appendChild(updateUserButton);
 
-        this.appendToForm(header, userNameField, passwordField, repeatPasswordField, buttonBar);
+        this.appendToForm(header, infoHeader, userNameField, passwordField, repeatPasswordField, buttonBar);
         return this.getForm();
     }
 }

--- a/frontend/static/js/components/sideBar.js
+++ b/frontend/static/js/components/sideBar.js
@@ -80,26 +80,21 @@ let updateUser = async (userId) => {
 	const userService = new UserService();
 	try {
 		await userService.putRequest(userId, data);
-		notify('User updated successfully.');
 		if (username === savebleUsername)
 			localStorage.setItem('username', savebleUsername);
 
 		if (saveblePassword !== '') {
-			usernameField.value = '';
-			currentPasswordField.value = '';
-			newPasswordField.value = '';
+			notify('User updated successfully. Please log in again.');
 			localStorage.clear();
 			navigateTo('/logout');
+			return;
 		}
 
 	} catch (error) {
 		notify(error);
 	}
 
-	usernameField.value = '';
-	currentPasswordField.value = '';
-	newPasswordField.value = '';
-
+	notify('User updated successfully.');
 	navigateTo('/dashboard');
 };
 
@@ -127,14 +122,10 @@ const SideBar = async () => {
 
 	const UpdateModal = new UpdateUserModal(updateUser, localStorage.getItem('user_id'));
 	const editProfileBtn = sideBarButton(['sidebar-element', 'bg-primary'], 'Edit profile', () => {
-		document.body.appendChild(UpdateModal.dialog);
+		aside.appendChild(UpdateModal.dialog);
 		UpdateModal.dialog.showModal();
 	});
 
-	const viewProfileBtn = sideBarButton(
-		['sidebar-element', 'bg-primary'],
-		'View profile', () => navigateTo('/dashboard')
-	);
 	const profilePictureBtn = sideBarButton(
 		['sidebar-element', 'bg-primary'],
 		'Update profile picture',
@@ -163,7 +154,6 @@ const SideBar = async () => {
 	aside.appendChild(fileInput);
 	aside.appendChild(logoutBtn);
 	aside.appendChild(editProfileBtn);
-	aside.appendChild(viewProfileBtn);
 	aside.appendChild(profilePictureBtn);
 	aside.appendChild(createTournamentBtn);
 	aside.appendChild(deleteAccountBtn);

--- a/frontend/static/js/components/sideBar.js
+++ b/frontend/static/js/components/sideBar.js
@@ -92,6 +92,7 @@ let updateUser = async (userId) => {
 
 	} catch (error) {
 		notify(error);
+		return;
 	}
 
 	notify('User updated successfully.');


### PR DESCRIPTION
Fixed the bug from the editing user. If the user updates the password, we log them out so they have to login again. If the user just changes the username, we just save the new username and update the UI. Added some more information to the modal and the notifications depending on if we update just the username, and/or the password.

https://github.com/user-attachments/assets/091dec1c-c73f-4de9-bf41-53812e147188

