### PR TITLE
265 make certain backend queries ignore inactive users

### DIFF
--- a/backend/Friends/managers.py
+++ b/backend/Friends/managers.py
@@ -43,6 +43,11 @@ class FriendsManager(models.Manager):
 		return self.get(id=friendship_id)
 
 	def create_friendship(self, user_id, friend_id):
+		potential_friend = User.objects.filter(pk=friend_id).first()
+		if not potential_friend:
+			raise Exception("User to be added as friend does not exist.")
+		if not potential_friend.is_active:
+			raise Exception("Cannot add deleted user as friend.")
 		return self.create(user_id=user_id, friend_id=friend_id)
 
 	def delete_friendship(self, user_id, friend_id):
@@ -54,3 +59,14 @@ class FriendsManager(models.Manager):
 				user_friend.delete()
 			if friend_user.exists():
 				friend_user.delete()
+
+	def delete_user_friendships(self, user_id: int) -> None:
+		user_friends = self.filter(user_id=user_id)
+		friends_user = self.filter(friend_id=user_id)
+
+		try:
+			with transaction.atomic():
+				user_friends.delete()
+				friends_user.delete()
+		except Exception:
+			pass

--- a/backend/Friends/managers.py
+++ b/backend/Friends/managers.py
@@ -60,9 +60,9 @@ class FriendsManager(models.Manager):
 			if friend_user.exists():
 				friend_user.delete()
 
-	def delete_user_friendships(self, user_id: int) -> None:
-		user_friends = self.filter(user_id=user_id)
-		friends_user = self.filter(friend_id=user_id)
+	def delete_user_friendships(self, user: User) -> None:
+		user_friends = self.filter(user=user)
+		friends_user = self.filter(friend=user)
 
 		try:
 			with transaction.atomic():

--- a/backend/Friends/views.py
+++ b/backend/Friends/views.py
@@ -31,7 +31,7 @@ class FriendsListView(APIView):
 		user_id = request.user.id
 		friend_id = request.data.get('friend_id')
 		if user_id == friend_id:
-			return Response({"message": "Can't add friendship for self."}, status=status.HTTP_400_BAD_REQUEST)
+			return Response({"message": "Can't add self as friend."}, status=status.HTTP_400_BAD_REQUEST)
 		try:
 			friend = Friend.objects.create_friendship(user_id, friend_id)
 		except Exception as e:

--- a/backend/Match/views.py
+++ b/backend/Match/views.py
@@ -38,7 +38,7 @@ class MatchView(APIView):
         pong_match_url = f'ws://localhost:8080/pong/{match.id}?token={token.token}'
         return Response(pong_match_url, status=status.HTTP_200_OK)
 
-class MatchHistory(APIView):
+class MatchHistoryView(APIView):
      def get(self, request):
         user_id = request.query_params.get('user_id')
         user = get_object_or_404(User, pk = user_id)

--- a/backend/Match/views.py
+++ b/backend/Match/views.py
@@ -37,8 +37,8 @@ class MatchView(APIView):
       
       
 class MatchHistoryView(APIView):
-     @method_decorator(must_be_authenticated)
-     def get(self, request):
+    @method_decorator(must_be_authenticated)
+    def get(self, request):
         user_id = request.query_params.get('user_id')
         user = get_object_or_404(User, pk = user_id)
         if not isinstance(user, User):

--- a/backend/User/mixins.py
+++ b/backend/User/mixins.py
@@ -13,7 +13,7 @@ from .models import User, ProfilePicture
 from .validators import validate_image
 from .serializers import UserInputSerializer, UserOutputSerializer
 from Tournament.mixins import ChangeDeletedUserTournamentNamesMixin
-from Friends.managers import FriendsManager
+from Friends.models import Friend
 
 class GetAllUsersMixin:
     """
@@ -151,7 +151,7 @@ class DeleteUserMixin(ChangeDeletedUserTournamentNamesMixin):
         result.save()
 
         self.change_tournament_player_names_to_deleted(result)
-        FriendsManager.delete_user_friendships(user_id)
+        Friend.objects.delete_user_friendships(result)
 
         return Response(status=status.HTTP_204_NO_CONTENT)
 

--- a/backend/User/mixins.py
+++ b/backend/User/mixins.py
@@ -13,11 +13,11 @@ from .serializers import UserInputSerializer, UserOutputSerializer
 from Tournament.mixins import ChangeDeletedUserTournamentNamesMixin
 
 class GetAllUsersMixin:
-	"""
-	Mixin to get all Users.
-	"""
-	def get_all_users(self) -> QuerySet:
-		return User.objects.all()
+    """
+    Mixin to get all Users.
+    """
+    def get_all_users(self) -> QuerySet:
+        return User.objects.filter(is_active=True)
 
 class GetUsersWithUsernameContainsMixin:
 	"""
@@ -28,18 +28,18 @@ class GetUsersWithUsernameContainsMixin:
 		if not username_contains:
 			return User.objects.none()
 
-		return User.objects.filter(username__icontains=username_contains).exclude(id=request.user.id)
+		return User.objects.filter(username__icontains=username_contains, is_active=True).exclude(id=request.user.id)
 
 class GetUserMixin:
 	"""
 	Mixin to get a user by ID.
 	"""
 	def get_user(self, user_id: int) -> User | Response:
-		result = get_object_or_404(User, pk=user_id)
-		if not isinstance(result, User):
+		user = User.objects.filter(pk=user_id, is_active=True).first()
+		if not isinstance(user, User):
 				return Response({'message': 'User not found'}, status=status.HTTP_404_NOT_FOUND)
 
-		return result
+		return user
 
 
 class CreateUserMixin:
@@ -84,7 +84,7 @@ class UpdateUserMixin:
 			outputSerializer = UserOutputSerializer(result)
 			return Response(outputSerializer.data, status=status.HTTP_200_OK)
 		except Exception as e:
-			return Response({"message": f"{str(e)}"}, status=status.HTTP_400_BAD_REQUEST)
+			return Response({"message": f"Updating the user failed"}, status=status.HTTP_400_BAD_REQUEST)
 
 
 class AuthenticateUserMixin:

--- a/backend/User/mixins.py
+++ b/backend/User/mixins.py
@@ -7,10 +7,12 @@ from django.utils.crypto import get_random_string
 from django.core.exceptions import ValidationError
 from django.shortcuts import get_object_or_404
 import base64
+
 from .models import User, ProfilePicture
 from .validators import validate_image
 from .serializers import UserInputSerializer, UserOutputSerializer
 from Tournament.mixins import ChangeDeletedUserTournamentNamesMixin
+from Friends.managers import FriendsManager
 
 class GetAllUsersMixin:
     """
@@ -146,6 +148,7 @@ class DeleteUserMixin(ChangeDeletedUserTournamentNamesMixin):
         result.save()
 
         self.change_tournament_player_names_to_deleted(result)
+        FriendsManager.delete_user_friendships(user_id)
 
         return Response(status=status.HTTP_204_NO_CONTENT)
 

--- a/backend/User/mixins.py
+++ b/backend/User/mixins.py
@@ -151,32 +151,32 @@ class DeleteUserMixin(ChangeDeletedUserTournamentNamesMixin):
 
 
 class SaveUserProfilePictureMixin(GetUserMixin):
-	"""
-	Mixin to save a user's profile picture.
-	"""
-	def save_profile_picture(self, request: Request, user_id: int) -> Response:
-		result = self.get_user(user_id)
-		if not isinstance(result, User):
-			 return result
+    """
+    Mixin to save a user's profile picture.
+    """
+    def save_profile_picture(self, request: Request, user_id: int) -> Response:
+        result = self.get_user(user_id)
+        if not isinstance(result, User):
+                return result
 
-		if 'file' not in request.FILES:
-			return Response(status=status.HTTP_400_BAD_REQUEST)
+        if 'file' not in request.FILES:
+            return Response(status=status.HTTP_400_BAD_REQUEST)
 
-		file = request.FILES['file']
+        file = request.FILES['file']
 
-		try:
-			validate_image(file)
-		except ValidationError as e:
-			return Response({"message": e.messages[0]}, status=status.HTTP_400_BAD_REQUEST)
+        try:
+            validate_image(file)
+        except ValidationError as e:
+            return Response({"message": e.messages[0]}, status=status.HTTP_400_BAD_REQUEST)
 
-		try:
-			profile_picture = ProfilePicture.objects.get(user=result)
-			profile_picture.picture = file
-		except ProfilePicture.DoesNotExist:
-			profile_picture = ProfilePicture(user=result, picture=file)
+        try:
+            profile_picture = ProfilePicture.objects.get(user=result)
+            profile_picture.picture = file
+        except ProfilePicture.DoesNotExist:
+            profile_picture = ProfilePicture(user=result, picture=file)
 
-		profile_picture.save()
-		return Response(status=status.HTTP_200_OK)
+        profile_picture.save()
+        return Response(status=status.HTTP_200_OK)
 
 
 class GetProfilePictureMixin(GetUserMixin):

--- a/backend/backend/urls.py
+++ b/backend/backend/urls.py
@@ -33,7 +33,7 @@ from Friends.views import FriendsListView, \
 from Tokens.views import SingleMatchGuestTokenView
 
 from Match.views import MatchView, \
-							MatchHistory
+							MatchHistoryView
 
 from Tournament.views import TournamentListView, \
 								TournamentDetailView, \
@@ -65,7 +65,7 @@ urlpatterns = [
 
 	# Match Views
 	path('match/', MatchView.as_view()),
-	path('matches/', MatchHistory.as_view()),
+	path('matches/', MatchHistoryView.as_view()),
 
 	# Tournament views
 	path('tournaments/', TournamentListView.as_view()),

--- a/backend/leaderboard/mixins.py
+++ b/backend/leaderboard/mixins.py
@@ -7,7 +7,7 @@ from User.models import User
 class LeaderBoardTableMixin:
 	def leader_table_response(self):
 			self.leader_table = LeaderBoardTable
-			users_with_most_wins = User.objects.annotate(
+			users_with_most_wins = User.objects.filter(is_active=True).annotate(
 				total_wins=Count('players', filter=Q(players__match_winner=True))
 			).order_by('-total_wins')
 

--- a/backend/pong/consumers.py
+++ b/backend/pong/consumers.py
@@ -113,6 +113,8 @@ class PongConsumer(AsyncWebsocketConsumer):
                     return False
                 if match_token.user_right_side is not None:
                     self.player_right = Player.objects.filter(match=self.match, user_id=match_token.user_right_side).first()
+                    if not self.player_right:
+                        return False
                 else:
                     self.ai_opponent = True
                 return True

--- a/backend/pong/consumers.py
+++ b/backend/pong/consumers.py
@@ -98,8 +98,8 @@ class PongConsumer(AsyncWebsocketConsumer):
     def authenticate_match_token_and_fetch_match_and_players(self, token, match_id):
         try:
             with transaction.atomic():
-                match_token = MatchToken.objects.get(token=token)
-                if not match_token.is_active or match_token.is_expired():
+                match_token = MatchToken.objects.filter(token=token).first()
+                if not match_token or not match_token.is_active or match_token.is_expired():
                     return False
 
                 match_token.is_active = False
@@ -113,7 +113,7 @@ class PongConsumer(AsyncWebsocketConsumer):
                     self.ai_opponent = True
                 return True
 
-        except (MatchToken.DoesNotExist, Match.DoesNotExist, Player.DoesNotExist):
+        except Exception:
             return False
 
     @database_sync_to_async

--- a/backend/pong/consumers.py
+++ b/backend/pong/consumers.py
@@ -105,8 +105,12 @@ class PongConsumer(AsyncWebsocketConsumer):
                 match_token.is_active = False
                 match_token.save()
 
-                self.match = Match.objects.get(pk=match_id)
+                self.match = Match.objects.filter(pk=match_id).first()
+                if not self.match:
+                    return False
                 self.player_left = Player.objects.filter(match=self.match, user_id=match_token.user_left_side).first()
+                if not self.player_left:
+                    return False
                 if match_token.user_right_side is not None:
                     self.player_right = Player.objects.filter(match=self.match, user_id=match_token.user_right_side).first()
                 else:

--- a/backend/stats/mixins.py
+++ b/backend/stats/mixins.py
@@ -37,7 +37,7 @@ class UserTableMixin:
 		return win_streak
 	
 	def get_users_with_most_wins(self):
-		return  User.objects.annotate(total_wins=Count('players', filter=Q(players__match_winner=True))).order_by('-total_wins')
+		return  User.objects.filter(is_active=True).annotate(total_wins=Count('players', filter=Q(players__match_winner=True))).order_by('-total_wins')
 
 	def get_position_in_leaderboard(self, user: User):
 		users_with_most_wins = self.get_users_with_most_wins()

--- a/backend/stats/views.py
+++ b/backend/stats/views.py
@@ -14,7 +14,7 @@ from shared_utilities.decorators import must_be_authenticated
 class StatsView(APIView, UserTableMixin):
 	@method_decorator(must_be_authenticated)
 	def get(self, request, user_id):
-		user = User.objects.filter(id = user_id).first()
+		user = User.objects.filter(id = user_id, is_active=True).first()
 		if not user:
 			return Response({"message": "User was not found"}, status=status.HTTP_404_NOT_FOUND)
 		wins = self.get_wins_count(user)


### PR DESCRIPTION
Made some changes to certain queries to filter out inactive users. These queries have to do with Users, Friends and stat stuff.

Some other minor changes:
- improved consumers.py authentication function so that it won't throw uncaught exceptions
- changed MatchHistory name to MatchHistoryView
- created new MatchManager function delete_user_friendships; added the function to DeleteUserMixin