### PR TITLE
292 add more test to the new rest api tests postman collection

### DIFF
--- a/backend/Match/views.py
+++ b/backend/Match/views.py
@@ -15,22 +15,27 @@ class MatchView(APIView):
     def get(self, request):
         token_str = request.query_params.get('token')
         if not token_str or token_str == 'null':
-            return Response({"message": "Token parameter is required"}, status=status.HTTP_400_BAD_REQUEST)
+            return Response({"message": "Token parameter is required."}, status=status.HTTP_400_BAD_REQUEST)
 
         try:
             token = MatchToken.objects.get(token=token_str)
-        except MatchToken.DoesNotExist:
-            return Response({"message": "Invalid token"}, status=status.HTTP_400_BAD_REQUEST)
+        except Exception:
+            return Response({"message": "Invalid token."}, status=status.HTTP_400_BAD_REQUEST)
+        
+        if token.already_used_to_get_url == True:
+            return Response({"message": "Token already used to get match url."}, status=status.HTTP_403_FORBIDDEN)
+        token.already_used_to_get_url = True
+        token.save()
 
         if not token.is_active or token.is_expired():
-            return Response({"message": "Expired token"}, status=status.HTTP_403_FORBIDDEN)
+            return Response({"message": "Expired token."}, status=status.HTTP_403_FORBIDDEN)
         if token.user_left_side.id != request.user.id:
-            return Response({"message": "You are not the host user in the token"}, status=status.HTTP_401_UNAUTHORIZED)
+            return Response({"message": "You are not the host user in the token."}, status=status.HTTP_401_UNAUTHORIZED)
 
         match = MatchSetupManager.create_match_and_its_players(token)
 
         if not match:
-            return Response({"message": "Something went wrong when creating the match and players"}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response({"message": "Something went wrong when creating the match and players."}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
         pong_match_url = f'ws://localhost:8080/pong/{match.id}?token={token.token}'
         return Response(pong_match_url, status=status.HTTP_200_OK)

--- a/backend/Tokens/models.py
+++ b/backend/Tokens/models.py
@@ -10,6 +10,7 @@ class AbstractToken(models.Model):
     created_at = models.DateTimeField(auto_now_add=True)
     expires_at = models.DateTimeField()
     is_active = models.BooleanField(default=True)
+    already_used_to_get_url = models.BooleanField(default=False)
 
     class Meta:
         abstract = True

--- a/backend/Tokens/views.py
+++ b/backend/Tokens/views.py
@@ -26,7 +26,6 @@ class SingleMatchGuestTokenView(APIView, AuthenticateUserMixin):
 			token_serializer = MatchTokenSerializer(token)
 			return Response({
 				'token': token_serializer.data,
-				'guest_user': ''
 			}, status=status.HTTP_201_CREATED)
 
 		result = self.authenticate_user(request)

--- a/backend/Tournament/managers.py
+++ b/backend/Tournament/managers.py
@@ -14,8 +14,6 @@ from Match.models import Match
 from Match.matchState import MatchState
 from Player.models import Player
 
-import sys
-
 class TournamentSetupManager:
     @staticmethod
     def create_tournament_and_tournament_player_for_host(validated_data: TournamentCreationSerializer.validated_data):

--- a/backend/Tournament/managers.py
+++ b/backend/Tournament/managers.py
@@ -14,6 +14,7 @@ from Match.models import Match
 from Match.matchState import MatchState
 from Player.models import Player
 
+import sys
 
 class TournamentSetupManager:
     @staticmethod
@@ -21,13 +22,16 @@ class TournamentSetupManager:
         try:
             with transaction.atomic():
                 tournament = Tournament.objects.create(
-                    name=validated_data['name'] if validated_data['name'] else None,
+                    name=validated_data.get('name', None),
                     host_user=validated_data['host_user'],
                     player_amount=validated_data['player_amount'],
                     expire_ts=timezone.now() + timedelta(TOURNAMENT_EXPIRY_TIME_SECONDS),
                 )
-
-                TournamentPlayerManager.create_tournament_player(tournament, tournament.host_user, validated_data['host_user_display_name'] if validated_data['host_user_display_name'] else None)
+                try:
+                    TournamentPlayerManager.create_tournament_player(tournament, tournament.host_user, validated_data.get('host_user_display_name', None))
+                except Exception as e:
+                    tournament.delete()
+                    raise Exception(e)
 
                 return tournament
 

--- a/backend/Tournament/views.py
+++ b/backend/Tournament/views.py
@@ -14,9 +14,6 @@ from Tokens.managers import MatchTokenManager
 from shared_utilities.decorators import must_be_authenticated, \
 											validate_tournament_request
 
-
-import sys
-
 class TournamentListView(APIView):
 	@method_decorator(must_be_authenticated)
 	def post(self, request):

--- a/backend/Tournament/views.py
+++ b/backend/Tournament/views.py
@@ -58,7 +58,7 @@ class TournamentDetailView(APIView):
 				serializer = TournamentSerializers.in_progress(tournament)
 				return Response(serializer.data, status=status.HTTP_200_OK)
 			except Exception as e:
-				return Response({"message": str(e)}, status=status.HTTP_400_BAD_REQUEST)
+				return Response({"message": "Starting tournament failed."}, status=status.HTTP_400_BAD_REQUEST)
 
 		elif tournament.state == TournamentState.IN_PROGRESS:
 			TournamentManager.in_progress.abort_tournament(tournament)

--- a/backend/Tournament/views.py
+++ b/backend/Tournament/views.py
@@ -14,6 +14,9 @@ from Tokens.managers import MatchTokenManager
 from shared_utilities.decorators import must_be_authenticated, \
 											validate_tournament_request
 
+
+import sys
+
 class TournamentListView(APIView):
 	@method_decorator(must_be_authenticated)
 	def post(self, request):
@@ -58,7 +61,7 @@ class TournamentDetailView(APIView):
 				serializer = TournamentSerializers.in_progress(tournament)
 				return Response(serializer.data, status=status.HTTP_200_OK)
 			except Exception as e:
-				return Response({"message": "Updating the tournament failed"}, status=status.HTTP_400_BAD_REQUEST)
+				return Response({"message": str(e)}, status=status.HTTP_400_BAD_REQUEST)
 
 		elif tournament.state == TournamentState.IN_PROGRESS:
 			TournamentManager.in_progress.abort_tournament(tournament)

--- a/tests/postman_collection.json
+++ b/tests/postman_collection.json
@@ -1,10 +1,10 @@
 {
 	"info": {
-		"_postman_id": "d68fcdc8-4b27-42e5-b4e5-ad0094f847d6",
+		"_postman_id": "c7015771-7a47-434d-9842-18288290efe0",
 		"name": "Rest API tests",
 		"description": "A collection of REST API tests for the backend.\n\nBe aware that the tests need to be run in order, so always run the User requests -folders before creating friendships, for example.",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "33991974"
+		"_exporter_id": "34213706"
 	},
 	"item": [
 		{
@@ -3358,6 +3358,1838 @@
 					"response": []
 				}
 			]
+		},
+		{
+			"name": "Test matches",
+			"item": [
+				{
+					"name": "Login User 1",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Response status code is 202\", function () {",
+									"    pm.expect(pm.response.code).to.equal(202);",
+									"});",
+									"",
+									"// Test to check if the response contains the 'csrftoken' and 'sessionid' cookies",
+									"pm.test(\"Response contains 'csrftoken' and 'sessionid' cookies\", function() {",
+									"    pm.expect(pm.response.headers.has('Set-Cookie')).to.be.true;",
+									"    var setCookieHeaders = pm.response.headers.all().filter(header => header.key === 'Set-Cookie');",
+									"    var cookieValues = setCookieHeaders.map(header => header.value);",
+									"    pm.expect(cookieValues.join()).to.include('csrftoken').and.to.include('sessionid');",
+									"});",
+									"",
+									"// Extract the CSRF token from cookies",
+									"var xsrfCookie = pm.cookies.get(\"csrftoken\");",
+									"pm.environment.set(\"csrftoken_1\", xsrfCookie);",
+									"",
+									"// Extract the session ID from cookies",
+									"var sessionIdCookie = pm.cookies.get(\"sessionid\");",
+									"pm.environment.set(\"sessionid_1\", sessionIdCookie);"
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"username\": \"{{username_1}}\",\n    \"password\": \"{{password_1}}\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{baseurl}}/login/",
+							"host": [
+								"{{baseurl}}"
+							],
+							"path": [
+								"login",
+								""
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "get AI match token",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									"// Pre-Request Script",
+									"// Get the cookie values from the environment variables",
+									"const sessionId = pm.environment.get('sessionid_1');",
+									"const csrftoken = pm.environment.get('csrftoken_1');",
+									"const cookieValues = 'csrftoken=' + csrftoken + '; sessionid=' + sessionId;",
+									"",
+									"// Set the cookie for the request if it exists",
+									"if (sessionId && csrftoken) {",
+									"    pm.request.headers.add({",
+									"        key: 'Cookie',",
+									"        value: cookieValues",
+									"    });",
+									"    ",
+									"    // Also set the CSRF token in the headers",
+									"    pm.request.headers.add({",
+									"        key: 'X-CSRFToken',",
+									"        value: csrftoken",
+									"    });",
+									"}"
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Response status code is 201\", function () {",
+									"    pm.expect(pm.response.code).to.equal(201);",
+									"});",
+									"",
+									"// Updated test to check if the token field exists in the response body",
+									"pm.test(\"Response has token field\", function() {",
+									"    pm.expect(pm.response.json().token).to.exist;",
+									"});",
+									"",
+									"// Store the value of the \"token\" field in the Test environment as the \"ai_match_token\" variable",
+									"var jsonData = pm.response.json();",
+									"pm.environment.set(\"ai_match_token\", jsonData.token.token);"
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"username\": \"{{username_1}}\",\n    \"password\": \"{{password_1}}\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{baseurl}}/tokens/match/?ai_opponent=true",
+							"host": [
+								"{{baseurl}}"
+							],
+							"path": [
+								"tokens",
+								"match",
+								""
+							],
+							"query": [
+								{
+									"key": "ai_opponent",
+									"value": "true"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "get AI match url (valid)",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									"// Pre-Request Script",
+									"// Get the cookie values from the environment variables",
+									"const sessionId = pm.environment.get('sessionid_1');",
+									"const csrftoken = pm.environment.get('csrftoken_1');",
+									"const cookieValues = 'csrftoken=' + csrftoken + '; sessionid=' + sessionId;",
+									"",
+									"// Set the cookie for the request if it exists",
+									"if (sessionId && csrftoken) {",
+									"    pm.request.headers.add({",
+									"        key: 'Cookie',",
+									"        value: cookieValues",
+									"    });",
+									"    ",
+									"    // Also set the CSRF token in the headers",
+									"    pm.request.headers.add({",
+									"        key: 'X-CSRFToken',",
+									"        value: csrftoken",
+									"    });",
+									"}"
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Response status code is 200\", function () {",
+									"    pm.expect(pm.response.code).to.equal(200);",
+									"});"
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						}
+					],
+					"protocolProfileBehavior": {
+						"disableBodyPruning": true
+					},
+					"request": {
+						"method": "GET",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{baseurl}}/match/?token={{ai_match_token}}",
+							"host": [
+								"{{baseurl}}"
+							],
+							"path": [
+								"match",
+								""
+							],
+							"query": [
+								{
+									"key": "token",
+									"value": "{{ai_match_token}}"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "get AI match url (invalid, already used to get URL)",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									"// Pre-Request Script",
+									"// Get the cookie values from the environment variables",
+									"const sessionId = pm.environment.get('sessionid_1');",
+									"const csrftoken = pm.environment.get('csrftoken_1');",
+									"const cookieValues = 'csrftoken=' + csrftoken + '; sessionid=' + sessionId;",
+									"",
+									"// Set the cookie for the request if it exists",
+									"if (sessionId && csrftoken) {",
+									"    pm.request.headers.add({",
+									"        key: 'Cookie',",
+									"        value: cookieValues",
+									"    });",
+									"    ",
+									"    // Also set the CSRF token in the headers",
+									"    pm.request.headers.add({",
+									"        key: 'X-CSRFToken',",
+									"        value: csrftoken",
+									"    });",
+									"}"
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Response status code is 403\", function () {",
+									"    pm.expect(pm.response.code).to.equal(403);",
+									"});"
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						}
+					],
+					"protocolProfileBehavior": {
+						"disableBodyPruning": true
+					},
+					"request": {
+						"method": "GET",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{baseurl}}/match/?token={{ai_match_token}}",
+							"host": [
+								"{{baseurl}}"
+							],
+							"path": [
+								"match",
+								""
+							],
+							"query": [
+								{
+									"key": "token",
+									"value": "{{ai_match_token}}"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "get match token (User 2)",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Response status code is 201\", function () {",
+									"    pm.expect(pm.response.code).to.equal(201);",
+									"});",
+									"",
+									"// Updated test to check if the token field exists in the response body",
+									"pm.test(\"Response has token field\", function() {",
+									"    pm.expect(pm.response.json().token).to.exist;",
+									"});",
+									"",
+									"// Store the value of the \"token\" field in the Test environment as the \"match_token\" variable",
+									"var jsonData = pm.response.json();",
+									"pm.environment.set(\"match_token\", jsonData.token.token);"
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									"// Pre-Request Script",
+									"// Get the cookie values from the environment variables",
+									"const sessionId = pm.environment.get('sessionid_1');",
+									"const csrftoken = pm.environment.get('csrftoken_1');",
+									"const cookieValues = 'csrftoken=' + csrftoken + '; sessionid=' + sessionId;",
+									"",
+									"// Set the cookie for the request if it exists",
+									"if (sessionId && csrftoken) {",
+									"    pm.request.headers.add({",
+									"        key: 'Cookie',",
+									"        value: cookieValues",
+									"    });",
+									"    ",
+									"    // Also set the CSRF token in the headers",
+									"    pm.request.headers.add({",
+									"        key: 'X-CSRFToken',",
+									"        value: csrftoken",
+									"    });",
+									"}"
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"username\": \"{{username_2}}\",\n    \"password\": \"{{password_2}}\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{baseurl}}/tokens/match/",
+							"host": [
+								"{{baseurl}}"
+							],
+							"path": [
+								"tokens",
+								"match",
+								""
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "get match url (User 2, valid)",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									"// Pre-Request Script",
+									"// Get the cookie values from the environment variables",
+									"const sessionId = pm.environment.get('sessionid_1');",
+									"const csrftoken = pm.environment.get('csrftoken_1');",
+									"const cookieValues = 'csrftoken=' + csrftoken + '; sessionid=' + sessionId;",
+									"",
+									"// Set the cookie for the request if it exists",
+									"if (sessionId && csrftoken) {",
+									"    pm.request.headers.add({",
+									"        key: 'Cookie',",
+									"        value: cookieValues",
+									"    });",
+									"    ",
+									"    // Also set the CSRF token in the headers",
+									"    pm.request.headers.add({",
+									"        key: 'X-CSRFToken',",
+									"        value: csrftoken",
+									"    });",
+									"}"
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Response status code is 200\", function () {",
+									"    pm.expect(pm.response.code).to.equal(200);",
+									"});"
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						}
+					],
+					"protocolProfileBehavior": {
+						"disableBodyPruning": true
+					},
+					"request": {
+						"method": "GET",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{baseurl}}/match/?token={{match_token}}",
+							"host": [
+								"{{baseurl}}"
+							],
+							"path": [
+								"match",
+								""
+							],
+							"query": [
+								{
+									"key": "token",
+									"value": "{{match_token}}"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "get match token (User 3)",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Response status code is 201\", function () {",
+									"    pm.expect(pm.response.code).to.equal(201);",
+									"});",
+									"",
+									"// Updated test to check if the token field exists in the response body",
+									"pm.test(\"Response has token field\", function() {",
+									"    pm.expect(pm.response.json().token).to.exist;",
+									"});",
+									"",
+									"// Store the value of the \"token\" field in the Test environment as the \"match_token\" variable",
+									"var jsonData = pm.response.json();",
+									"pm.environment.set(\"match_token\", jsonData.token.token);"
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									"// Pre-Request Script",
+									"// Get the cookie values from the environment variables",
+									"const sessionId = pm.environment.get('sessionid_1');",
+									"const csrftoken = pm.environment.get('csrftoken_1');",
+									"const cookieValues = 'csrftoken=' + csrftoken + '; sessionid=' + sessionId;",
+									"",
+									"// Set the cookie for the request if it exists",
+									"if (sessionId && csrftoken) {",
+									"    pm.request.headers.add({",
+									"        key: 'Cookie',",
+									"        value: cookieValues",
+									"    });",
+									"    ",
+									"    // Also set the CSRF token in the headers",
+									"    pm.request.headers.add({",
+									"        key: 'X-CSRFToken',",
+									"        value: csrftoken",
+									"    });",
+									"}"
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"username\": \"{{username_3}}\",\n    \"password\": \"{{password_3}}\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{baseurl}}/tokens/match/",
+							"host": [
+								"{{baseurl}}"
+							],
+							"path": [
+								"tokens",
+								"match",
+								""
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "invalidate token (User 3)",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Response status code is 200\", function () {",
+									"    pm.expect(pm.response.code).to.equal(200);",
+									"});"
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									"// Pre-Request Script",
+									"// Get the cookie values from the environment variables",
+									"const sessionId = pm.environment.get('sessionid_1');",
+									"const csrftoken = pm.environment.get('csrftoken_1');",
+									"const cookieValues = 'csrftoken=' + csrftoken + '; sessionid=' + sessionId;",
+									"",
+									"// Set the cookie for the request if it exists",
+									"if (sessionId && csrftoken) {",
+									"    pm.request.headers.add({",
+									"        key: 'Cookie',",
+									"        value: cookieValues",
+									"    });",
+									"    ",
+									"    // Also set the CSRF token in the headers",
+									"    pm.request.headers.add({",
+									"        key: 'X-CSRFToken',",
+									"        value: csrftoken",
+									"    });",
+									"}"
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						}
+					],
+					"request": {
+						"method": "PUT",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"token\": \"{{match_token}}\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{baseurl}}/tokens/match/",
+							"host": [
+								"{{baseurl}}"
+							],
+							"path": [
+								"tokens",
+								"match",
+								""
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "get match url (User 3, invalid token)",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									"// Pre-Request Script",
+									"// Get the cookie values from the environment variables",
+									"const sessionId = pm.environment.get('sessionid_1');",
+									"const csrftoken = pm.environment.get('csrftoken_1');",
+									"const cookieValues = 'csrftoken=' + csrftoken + '; sessionid=' + sessionId;",
+									"",
+									"// Set the cookie for the request if it exists",
+									"if (sessionId && csrftoken) {",
+									"    pm.request.headers.add({",
+									"        key: 'Cookie',",
+									"        value: cookieValues",
+									"    });",
+									"    ",
+									"    // Also set the CSRF token in the headers",
+									"    pm.request.headers.add({",
+									"        key: 'X-CSRFToken',",
+									"        value: csrftoken",
+									"    });",
+									"}"
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Response status code is 403\", function () {",
+									"    pm.expect(pm.response.code).to.equal(403);",
+									"});"
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						}
+					],
+					"protocolProfileBehavior": {
+						"disableBodyPruning": true
+					},
+					"request": {
+						"method": "GET",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{baseurl}}/match/?token={{match_token}}",
+							"host": [
+								"{{baseurl}}"
+							],
+							"path": [
+								"match",
+								""
+							],
+							"query": [
+								{
+									"key": "token",
+									"value": "{{match_token}}"
+								}
+							]
+						}
+					},
+					"response": []
+				}
+			],
+			"description": "Test backend's match views.  \nUsers 1, 2 and 3 are used in these tests."
+		},
+		{
+			"name": "Test tournaments",
+			"item": [
+				{
+					"name": "4 player tournaments",
+					"item": [
+						{
+							"name": "Login User 1",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Response status code is 202\", function () {",
+											"    pm.expect(pm.response.code).to.equal(202);",
+											"});",
+											"",
+											"// Test to check if the response contains the 'csrftoken' and 'sessionid' cookies",
+											"pm.test(\"Response contains 'csrftoken' and 'sessionid' cookies\", function() {",
+											"    pm.expect(pm.response.headers.has('Set-Cookie')).to.be.true;",
+											"    var setCookieHeaders = pm.response.headers.all().filter(header => header.key === 'Set-Cookie');",
+											"    var cookieValues = setCookieHeaders.map(header => header.value);",
+											"    pm.expect(cookieValues.join()).to.include('csrftoken').and.to.include('sessionid');",
+											"});",
+											"",
+											"// Extract the CSRF token from cookies",
+											"var xsrfCookie = pm.cookies.get(\"csrftoken\");",
+											"pm.environment.set(\"csrftoken_1\", xsrfCookie);",
+											"",
+											"// Extract the session ID from cookies",
+											"var sessionIdCookie = pm.cookies.get(\"sessionid\");",
+											"pm.environment.set(\"sessionid_1\", sessionIdCookie);"
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"username\": \"{{username_1}}\",\n    \"password\": \"{{password_1}}\"\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseurl}}/login/",
+									"host": [
+										"{{baseurl}}"
+									],
+									"path": [
+										"login",
+										""
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "start tournament (invalid, no player_amount)",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Response status code is 400\", function () {",
+											"    pm.expect(pm.response.code).to.equal(400);",
+											"});",
+											""
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"// Pre-Request Script",
+											"// Get the cookie values from the environment variables",
+											"const sessionId = pm.environment.get('sessionid_1');",
+											"const csrftoken = pm.environment.get('csrftoken_1');",
+											"const cookieValues = 'csrftoken=' + csrftoken + '; sessionid=' + sessionId;",
+											"",
+											"// Set the cookie for the request if it exists",
+											"if (sessionId && csrftoken) {",
+											"    pm.request.headers.add({",
+											"        key: 'Cookie',",
+											"        value: cookieValues",
+											"    });",
+											"    ",
+											"    // Also set the CSRF token in the headers",
+											"    pm.request.headers.add({",
+											"        key: 'X-CSRFToken',",
+											"        value: csrftoken",
+											"    });",
+											"}"
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"host_user_display_name\": \"tournament_host_user\"\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseurl}}/tournaments/",
+									"host": [
+										"{{baseurl}}"
+									],
+									"path": [
+										"tournaments",
+										""
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "start tournament (invalid, invalid player_amount)",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Response status code is 400\", function () {",
+											"    pm.expect(pm.response.code).to.equal(400);",
+											"});",
+											""
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"// Pre-Request Script",
+											"// Get the cookie values from the environment variables",
+											"const sessionId = pm.environment.get('sessionid_1');",
+											"const csrftoken = pm.environment.get('csrftoken_1');",
+											"const cookieValues = 'csrftoken=' + csrftoken + '; sessionid=' + sessionId;",
+											"",
+											"// Set the cookie for the request if it exists",
+											"if (sessionId && csrftoken) {",
+											"    pm.request.headers.add({",
+											"        key: 'Cookie',",
+											"        value: cookieValues",
+											"    });",
+											"    ",
+											"    // Also set the CSRF token in the headers",
+											"    pm.request.headers.add({",
+											"        key: 'X-CSRFToken',",
+											"        value: csrftoken",
+											"    });",
+											"}"
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"player_amount\": 3,\n    \"host_user_display_name\": \"tournament_host_user\"\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseurl}}/tournaments/",
+									"host": [
+										"{{baseurl}}"
+									],
+									"path": [
+										"tournaments",
+										""
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "start tournament (valid)",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Response status code is 201\", function () {",
+											"    pm.expect(pm.response.code).to.equal(201);",
+											"});",
+											"",
+											"// Store the value of the \"tournament.id\" field in the Test environment as the \"tournament_id\" variable",
+											"var jsonData = pm.response.json();",
+											"pm.environment.set(\"tournament_id\", jsonData.tournament.id);"
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"// Pre-Request Script",
+											"// Get the cookie values from the environment variables",
+											"const sessionId = pm.environment.get('sessionid_1');",
+											"const csrftoken = pm.environment.get('csrftoken_1');",
+											"const cookieValues = 'csrftoken=' + csrftoken + '; sessionid=' + sessionId;",
+											"",
+											"// Set the cookie for the request if it exists",
+											"if (sessionId && csrftoken) {",
+											"    pm.request.headers.add({",
+											"        key: 'Cookie',",
+											"        value: cookieValues",
+											"    });",
+											"    ",
+											"    // Also set the CSRF token in the headers",
+											"    pm.request.headers.add({",
+											"        key: 'X-CSRFToken',",
+											"        value: csrftoken",
+											"    });",
+											"}"
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"host_user_display_name\": \"tournament_host_user\",\n    \"player_amount\": 4\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseurl}}/tournaments/",
+									"host": [
+										"{{baseurl}}"
+									],
+									"path": [
+										"tournaments",
+										""
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "add User 2 to tournament",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Response status code is 201\", function () {",
+											"    pm.expect(pm.response.code).to.equal(201);",
+											"});"
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"// Pre-Request Script",
+											"// Get the cookie values from the environment variables",
+											"const sessionId = pm.environment.get('sessionid_1');",
+											"const csrftoken = pm.environment.get('csrftoken_1');",
+											"const cookieValues = 'csrftoken=' + csrftoken + '; sessionid=' + sessionId;",
+											"",
+											"// Set the cookie for the request if it exists",
+											"if (sessionId && csrftoken) {",
+											"    pm.request.headers.add({",
+											"        key: 'Cookie',",
+											"        value: cookieValues",
+											"    });",
+											"    ",
+											"    // Also set the CSRF token in the headers",
+											"    pm.request.headers.add({",
+											"        key: 'X-CSRFToken',",
+											"        value: csrftoken",
+											"    });",
+											"}"
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"username\": \"{{username_2}}\",\n    \"password\": \"{{password_2}}\"\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseurl}}/tournaments/{{tournament_id}}/players/",
+									"host": [
+										"{{baseurl}}"
+									],
+									"path": [
+										"tournaments",
+										"{{tournament_id}}",
+										"players",
+										""
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "add User 3 to tournament",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Response status code is 201\", function () {",
+											"    pm.expect(pm.response.code).to.equal(201);",
+											"});"
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"// Pre-Request Script",
+											"// Get the cookie values from the environment variables",
+											"const sessionId = pm.environment.get('sessionid_1');",
+											"const csrftoken = pm.environment.get('csrftoken_1');",
+											"const cookieValues = 'csrftoken=' + csrftoken + '; sessionid=' + sessionId;",
+											"",
+											"// Set the cookie for the request if it exists",
+											"if (sessionId && csrftoken) {",
+											"    pm.request.headers.add({",
+											"        key: 'Cookie',",
+											"        value: cookieValues",
+											"    });",
+											"    ",
+											"    // Also set the CSRF token in the headers",
+											"    pm.request.headers.add({",
+											"        key: 'X-CSRFToken',",
+											"        value: csrftoken",
+											"    });",
+											"}"
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"username\": \"{{username_3}}\",\n    \"password\": \"{{password_3}}\"\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseurl}}/tournaments/{{tournament_id}}/players/",
+									"host": [
+										"{{baseurl}}"
+									],
+									"path": [
+										"tournaments",
+										"{{tournament_id}}",
+										"players",
+										""
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "add User 4 to tournament",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Response status code is 201\", function () {",
+											"    pm.expect(pm.response.code).to.equal(201);",
+											"});",
+											"",
+											"// Store the value of the \"tournament.id\" field in the Test environment as the \"tournament_id\" variable",
+											"var jsonData = pm.response.json();",
+											"pm.environment.set(\"tournament_player_id\", jsonData.id);"
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"// Pre-Request Script",
+											"// Get the cookie values from the environment variables",
+											"const sessionId = pm.environment.get('sessionid_1');",
+											"const csrftoken = pm.environment.get('csrftoken_1');",
+											"const cookieValues = 'csrftoken=' + csrftoken + '; sessionid=' + sessionId;",
+											"",
+											"// Set the cookie for the request if it exists",
+											"if (sessionId && csrftoken) {",
+											"    pm.request.headers.add({",
+											"        key: 'Cookie',",
+											"        value: cookieValues",
+											"    });",
+											"    ",
+											"    // Also set the CSRF token in the headers",
+											"    pm.request.headers.add({",
+											"        key: 'X-CSRFToken',",
+											"        value: csrftoken",
+											"    });",
+											"}"
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"username\": \"{{username_4}}\",\n    \"password\": \"{{password_4}}\"\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseurl}}/tournaments/{{tournament_id}}/players/",
+									"host": [
+										"{{baseurl}}"
+									],
+									"path": [
+										"tournaments",
+										"{{tournament_id}}",
+										"players",
+										""
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "remove User 4 from tournament",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Response status code is 204\", function () {",
+											"    pm.expect(pm.response.code).to.equal(204);",
+											"});"
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"// Pre-Request Script",
+											"// Get the cookie values from the environment variables",
+											"const sessionId = pm.environment.get('sessionid_1');",
+											"const csrftoken = pm.environment.get('csrftoken_1');",
+											"const cookieValues = 'csrftoken=' + csrftoken + '; sessionid=' + sessionId;",
+											"",
+											"// Set the cookie for the request if it exists",
+											"if (sessionId && csrftoken) {",
+											"    pm.request.headers.add({",
+											"        key: 'Cookie',",
+											"        value: cookieValues",
+											"    });",
+											"    ",
+											"    // Also set the CSRF token in the headers",
+											"    pm.request.headers.add({",
+											"        key: 'X-CSRFToken',",
+											"        value: csrftoken",
+											"    });",
+											"}"
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseurl}}/tournaments/{{tournament_id}}/players/{{tournament_player_id}}",
+									"host": [
+										"{{baseurl}}"
+									],
+									"path": [
+										"tournaments",
+										"{{tournament_id}}",
+										"players",
+										"{{tournament_player_id}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "start tournament (invalid, not enough players)",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Response status code is 400\", function () {",
+											"    pm.expect(pm.response.code).to.equal(400);",
+											"});"
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"// Pre-Request Script",
+											"// Get the cookie values from the environment variables",
+											"const sessionId = pm.environment.get('sessionid_1');",
+											"const csrftoken = pm.environment.get('csrftoken_1');",
+											"const cookieValues = 'csrftoken=' + csrftoken + '; sessionid=' + sessionId;",
+											"",
+											"// Set the cookie for the request if it exists",
+											"if (sessionId && csrftoken) {",
+											"    pm.request.headers.add({",
+											"        key: 'Cookie',",
+											"        value: cookieValues",
+											"    });",
+											"    ",
+											"    // Also set the CSRF token in the headers",
+											"    pm.request.headers.add({",
+											"        key: 'X-CSRFToken',",
+											"        value: csrftoken",
+											"    });",
+											"}"
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"method": "PATCH",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseurl}}/tournaments/{{tournament_id}}",
+									"host": [
+										"{{baseurl}}"
+									],
+									"path": [
+										"tournaments",
+										"{{tournament_id}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "add User 4 to tournament Copy",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Response status code is 201\", function () {",
+											"    pm.expect(pm.response.code).to.equal(201);",
+											"});",
+											"",
+											"// Store the value of the \"tournament.id\" field in the Test environment as the \"tournament_id\" variable",
+											"var jsonData = pm.response.json();",
+											"pm.environment.set(\"tournament_player_id\", jsonData.id);"
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"// Pre-Request Script",
+											"// Get the cookie values from the environment variables",
+											"const sessionId = pm.environment.get('sessionid_1');",
+											"const csrftoken = pm.environment.get('csrftoken_1');",
+											"const cookieValues = 'csrftoken=' + csrftoken + '; sessionid=' + sessionId;",
+											"",
+											"// Set the cookie for the request if it exists",
+											"if (sessionId && csrftoken) {",
+											"    pm.request.headers.add({",
+											"        key: 'Cookie',",
+											"        value: cookieValues",
+											"    });",
+											"    ",
+											"    // Also set the CSRF token in the headers",
+											"    pm.request.headers.add({",
+											"        key: 'X-CSRFToken',",
+											"        value: csrftoken",
+											"    });",
+											"}"
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"username\": \"{{username_4}}\",\n    \"password\": \"{{password_4}}\"\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseurl}}/tournaments/{{tournament_id}}/players/",
+									"host": [
+										"{{baseurl}}"
+									],
+									"path": [
+										"tournaments",
+										"{{tournament_id}}",
+										"players",
+										""
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "add User 5 to tournament (invalid, player limit))",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Response status code is 400\", function () {",
+											"    pm.expect(pm.response.code).to.equal(400);",
+											"});"
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"// Pre-Request Script",
+											"// Get the cookie values from the environment variables",
+											"const sessionId = pm.environment.get('sessionid_1');",
+											"const csrftoken = pm.environment.get('csrftoken_1');",
+											"const cookieValues = 'csrftoken=' + csrftoken + '; sessionid=' + sessionId;",
+											"",
+											"// Set the cookie for the request if it exists",
+											"if (sessionId && csrftoken) {",
+											"    pm.request.headers.add({",
+											"        key: 'Cookie',",
+											"        value: cookieValues",
+											"    });",
+											"    ",
+											"    // Also set the CSRF token in the headers",
+											"    pm.request.headers.add({",
+											"        key: 'X-CSRFToken',",
+											"        value: csrftoken",
+											"    });",
+											"}"
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"username\": \"{{username_5}}\",\n    \"password\": \"{{password_5}}\"\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseurl}}/tournaments/{{tournament_id}}/players/",
+									"host": [
+										"{{baseurl}}"
+									],
+									"path": [
+										"tournaments",
+										"{{tournament_id}}",
+										"players",
+										""
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "start tournament (valid)",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Response status code is 200\", function () {",
+											"    pm.expect(pm.response.code).to.equal(200);",
+											"});"
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"// Pre-Request Script",
+											"// Get the cookie values from the environment variables",
+											"const sessionId = pm.environment.get('sessionid_1');",
+											"const csrftoken = pm.environment.get('csrftoken_1');",
+											"const cookieValues = 'csrftoken=' + csrftoken + '; sessionid=' + sessionId;",
+											"",
+											"// Set the cookie for the request if it exists",
+											"if (sessionId && csrftoken) {",
+											"    pm.request.headers.add({",
+											"        key: 'Cookie',",
+											"        value: cookieValues",
+											"    });",
+											"    ",
+											"    // Also set the CSRF token in the headers",
+											"    pm.request.headers.add({",
+											"        key: 'X-CSRFToken',",
+											"        value: csrftoken",
+											"    });",
+											"}"
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"method": "PATCH",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseurl}}/tournaments/{{tournament_id}}",
+									"host": [
+										"{{baseurl}}"
+									],
+									"path": [
+										"tournaments",
+										"{{tournament_id}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "get tournament players",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Response status code is 200\", function () {",
+											"    pm.expect(pm.response.code).to.equal(200);",
+											"});"
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"// Pre-Request Script",
+											"// Get the cookie values from the environment variables",
+											"const sessionId = pm.environment.get('sessionid_1');",
+											"const csrftoken = pm.environment.get('csrftoken_1');",
+											"const cookieValues = 'csrftoken=' + csrftoken + '; sessionid=' + sessionId;",
+											"",
+											"// Set the cookie for the request if it exists",
+											"if (sessionId && csrftoken) {",
+											"    pm.request.headers.add({",
+											"        key: 'Cookie',",
+											"        value: cookieValues",
+											"    });",
+											"    ",
+											"    // Also set the CSRF token in the headers",
+											"    pm.request.headers.add({",
+											"        key: 'X-CSRFToken',",
+											"        value: csrftoken",
+											"    });",
+											"}"
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"protocolProfileBehavior": {
+								"disableBodyPruning": true
+							},
+							"request": {
+								"method": "GET",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseurl}}/tournaments/{{tournament_id}}/players/",
+									"host": [
+										"{{baseurl}}"
+									],
+									"path": [
+										"tournaments",
+										"{{tournament_id}}",
+										"players",
+										""
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "get tournament matches",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Response status code is 200\", function () {",
+											"    pm.expect(pm.response.code).to.equal(200);",
+											"});"
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"// Pre-Request Script",
+											"// Get the cookie values from the environment variables",
+											"const sessionId = pm.environment.get('sessionid_1');",
+											"const csrftoken = pm.environment.get('csrftoken_1');",
+											"const cookieValues = 'csrftoken=' + csrftoken + '; sessionid=' + sessionId;",
+											"",
+											"// Set the cookie for the request if it exists",
+											"if (sessionId && csrftoken) {",
+											"    pm.request.headers.add({",
+											"        key: 'Cookie',",
+											"        value: cookieValues",
+											"    });",
+											"    ",
+											"    // Also set the CSRF token in the headers",
+											"    pm.request.headers.add({",
+											"        key: 'X-CSRFToken',",
+											"        value: csrftoken",
+											"    });",
+											"}"
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"protocolProfileBehavior": {
+								"disableBodyPruning": true
+							},
+							"request": {
+								"method": "GET",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseurl}}/tournaments/{{tournament_id}}/players/",
+									"host": [
+										"{{baseurl}}"
+									],
+									"path": [
+										"tournaments",
+										"{{tournament_id}}",
+										"players",
+										""
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "get next_match url",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Response status code is 200\", function () {",
+											"    pm.expect(pm.response.code).to.equal(200);",
+											"});"
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"// Pre-Request Script",
+											"// Get the cookie values from the environment variables",
+											"const sessionId = pm.environment.get('sessionid_1');",
+											"const csrftoken = pm.environment.get('csrftoken_1');",
+											"const cookieValues = 'csrftoken=' + csrftoken + '; sessionid=' + sessionId;",
+											"",
+											"// Set the cookie for the request if it exists",
+											"if (sessionId && csrftoken) {",
+											"    pm.request.headers.add({",
+											"        key: 'Cookie',",
+											"        value: cookieValues",
+											"    });",
+											"    ",
+											"    // Also set the CSRF token in the headers",
+											"    pm.request.headers.add({",
+											"        key: 'X-CSRFToken',",
+											"        value: csrftoken",
+											"    });",
+											"}"
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"protocolProfileBehavior": {
+								"disableBodyPruning": true
+							},
+							"request": {
+								"method": "GET",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseurl}}/tournaments/{{tournament_id}}/matches/{{next_match}}",
+									"host": [
+										"{{baseurl}}"
+									],
+									"path": [
+										"tournaments",
+										"{{tournament_id}}",
+										"matches",
+										"{{next_match}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "abort tournament",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Response status code is 200\", function () {",
+											"    pm.expect(pm.response.code).to.equal(200);",
+											"});"
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"// Pre-Request Script",
+											"// Get the cookie values from the environment variables",
+											"const sessionId = pm.environment.get('sessionid_1');",
+											"const csrftoken = pm.environment.get('csrftoken_1');",
+											"const cookieValues = 'csrftoken=' + csrftoken + '; sessionid=' + sessionId;",
+											"",
+											"// Set the cookie for the request if it exists",
+											"if (sessionId && csrftoken) {",
+											"    pm.request.headers.add({",
+											"        key: 'Cookie',",
+											"        value: cookieValues",
+											"    });",
+											"    ",
+											"    // Also set the CSRF token in the headers",
+											"    pm.request.headers.add({",
+											"        key: 'X-CSRFToken',",
+											"        value: csrftoken",
+											"    });",
+											"}"
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"method": "PATCH",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseurl}}/tournaments/{{tournament_id}}",
+									"host": [
+										"{{baseurl}}"
+									],
+									"path": [
+										"tournaments",
+										"{{tournament_id}}"
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				}
+			],
+			"description": "Test backend's tournament views.\n\nUsers 1, 2, 3, 4 and 5 used in these tests."
 		}
 	],
 	"event": [

--- a/tests/postman_environment.json
+++ b/tests/postman_environment.json
@@ -1,5 +1,5 @@
 {
-	"id": "35df1b1b-6a4e-456e-a685-55c66e23796f",
+	"id": "e7c7d7db-81fc-4e13-b182-abbd7f9a0c2e",
 	"name": "Test environment",
 	"values": [
 		{
@@ -185,9 +185,39 @@
 			"value": "''",
 			"type": "default",
 			"enabled": true
+		},
+		{
+			"key": "ai_match_token",
+			"value": "''",
+			"type": "default",
+			"enabled": true
+		},
+		{
+			"key": "match_token",
+			"value": "''",
+			"type": "default",
+			"enabled": true
+		},
+		{
+			"key": "tournament_id",
+			"value": "''",
+			"type": "default",
+			"enabled": true
+		},
+		{
+			"key": "tournament_player_id",
+			"value": "''",
+			"type": "default",
+			"enabled": true
+		},
+		{
+			"key": "next_match",
+			"value": "''",
+			"type": "default",
+			"enabled": true
 		}
 	],
 	"_postman_variable_scope": "environment",
-	"_postman_exported_at": "2024-06-03T18:06:34.243Z",
-	"_postman_exported_using": "Postman/11.1.14"
+	"_postman_exported_at": "2024-07-26T11:16:31.379Z",
+	"_postman_exported_using": "Postman/11.4.0"
 }


### PR DESCRIPTION
This PR adds match and tournament tests to the (new) postman collection and environment.

Some other changes:
- prevent a single match token from creating multiple matches with a new flag.
- removed guest_user from the Response when creating AI match token
- improved create_tournament_and_tournament_player_for_host function
  - use get for validated data
  - delete tournament if creation of host tournament player fails
- added back exception string to PATCH TournamentDetailView Response message (tells that there aren't enough players to start tournament)