### PR TITLE
326-fix-host-tournament-player-missing-display-name

### DIFF
--- a/backend/Tournament/managers.py
+++ b/backend/Tournament/managers.py
@@ -25,8 +25,11 @@ class TournamentSetupManager:
                     player_amount=validated_data['player_amount'],
                     expire_ts=timezone.now() + timedelta(TOURNAMENT_EXPIRY_TIME_SECONDS),
                 )
+
+                display_name = validated_data.get('host_user_display_name', None)
+                username = tournament.host_user.username
                 try:
-                    TournamentPlayerManager.create_tournament_player(tournament, tournament.host_user, validated_data.get('host_user_display_name', None))
+                    TournamentPlayerManager.create_tournament_player(tournament, tournament.host_user, display_name or username)
                 except Exception as e:
                     tournament.delete()
                     raise Exception(e)


### PR DESCRIPTION
I noticed that the host tournament player's display_name was not showing when they won a match in a tournament. This was because I was setting the display_name as none if there wasn't a tournament_host_display_name in the TournamentCreationSerializer.

I've added a couple of lines that are similar to the TournamentPlayerListView POST method which fixes this bug.